### PR TITLE
EditorConfig: tabs for C# files

### DIFF
--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+indent_style = tab

--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -1,2 +1,5 @@
 [*.cs]
 indent_style = tab
+
+[.editorconfig]
+insert_final_newline = true


### PR DESCRIPTION
Since you seem to be using tabs for indentation, here's an editorconfig file to force VS2017 to use tabs instead of spaces within this solution.