### PR TITLE
Update UI in place when assigning/removing categories

### DIFF
--- a/Source/Depressurizer/MainForm.cs
+++ b/Source/Depressurizer/MainForm.cs
@@ -321,6 +321,83 @@ namespace Depressurizer
 			Cursor.Current = Cursors.Default;
 		}
 
+		private void QuickAddCategoryToSelectedGames(Category category)
+		{
+			if (lstGames.SelectedObjects.Count <= 0)
+			{
+				return;
+			}
+
+			Cursor.Current = Cursors.WaitCursor;
+
+			foreach (GameInfo gameInfo in _tlstGames.SelectedObjects)
+			{
+				if (gameInfo == null)
+				{
+					continue;
+				}
+
+
+				gameInfo.AddCategory(category);
+			}
+			lstGames.RefreshSelectedObjects();
+
+			UpdateCategoryCountInCategoryList(category);
+
+			AddRemoveCategoryContextMenu(category);
+			ResortToolStripItemCollection(contextGameRemCat.Items);
+
+			lstMultiCat.Items[category.Name].Checked = true;
+
+			MakeChange(true);
+
+			Cursor.Current = Cursors.Default;
+		}
+
+		private void QuickRemoveCategoryFromSelectedGames(Category category)
+		{
+			if (lstGames.SelectedObjects.Count <= 0)
+			{
+				return;
+			}
+
+			Cursor.Current = Cursors.WaitCursor;
+
+			foreach (GameInfo gameInfo in _tlstGames.SelectedObjects)
+			{
+				if (gameInfo == null)
+				{
+					continue;
+				}
+
+
+				gameInfo.RemoveCategory(category);
+			}
+			lstGames.RefreshSelectedObjects();
+
+			UpdateCategoryCountInCategoryList(category);
+
+			contextGameRemCat.Items.RemoveByKey(category.Name);
+			lstMultiCat.Items[category.Name].Checked = false;
+
+
+			MakeChange(true);
+
+			Cursor.Current = Cursors.Default;
+		}
+
+		private void UpdateCategoryCountInCategoryList(Category category)
+		{
+			foreach (ListViewItem item in lstCategories.Items)
+			{
+				if (Object.ReferenceEquals(item.Tag, category))
+				{
+					item.Text = CategoryListViewItemText(category);
+				}
+			}
+		}
+
+
 		/// <summary>
 		///     Adds a new game. Displays the game dialog to the user.
 		/// </summary>
@@ -384,21 +461,18 @@ namespace Depressurizer
 		{
 			foreach (Category c in game.Categories)
 			{
-				bool found = false;
-				foreach (ToolStripItem i in contextGameRemCat.Items)
-				{
-					if (i.Text == c.Name)
-					{
-						found = true;
-					}
-				}
+				AddRemoveCategoryContextMenu(c);
+			}
+		}
 
-				if (!found)
-				{
-					ToolStripItem item = contextGameRemCat.Items.Add(c.Name);
-					item.Tag = c;
-					item.Click += contextGameRemCat_Category_Click;
-				}
+		private void AddRemoveCategoryContextMenu(Category c)
+		{
+			if (!contextGameRemCat.Items.ContainsKey(c.Name))
+			{
+				ToolStripItem item = contextGameRemCat.Items.Add(c.Name);
+				item.Tag = c;
+				item.Name = c.Name;
+				item.Click += contextGameRemCat_Category_Click;
 			}
 		}
 
@@ -1014,7 +1088,7 @@ namespace Depressurizer
 			{
 				ClearStatus();
 				Category c = menuItem.Tag as Category;
-				AddCategoryToSelectedGames(c, false);
+				QuickAddCategoryToSelectedGames(c);
 				FlushStatus();
 			}
 		}
@@ -1025,7 +1099,7 @@ namespace Depressurizer
 			if (c != null)
 			{
 				ClearStatus();
-				AddCategoryToSelectedGames(c, false);
+				QuickAddCategoryToSelectedGames(c);
 				FlushStatus();
 			}
 		}
@@ -1051,7 +1125,7 @@ namespace Depressurizer
 			{
 				ClearStatus();
 				Category c = menuItem.Tag as Category;
-				RemoveCategoryFromSelectedGames(c);
+				QuickRemoveCategoryFromSelectedGames(c);
 				FlushStatus();
 			}
 		}
@@ -1355,6 +1429,7 @@ namespace Depressurizer
 
 					ListViewItem listItem = new ListViewItem(c.Name);
 					listItem.Tag = c;
+					listItem.Name = c.Name;
 					listItem.StateImageIndex = 0;
 					lstMultiCat.Items.Add(listItem);
 				}
@@ -1840,7 +1915,7 @@ namespace Depressurizer
 					Category cat = item.Tag as Category;
 					if (cat != null)
 					{
-						AddCategoryToSelectedGames(cat, false);
+						QuickAddCategoryToSelectedGames(cat);
 					}
 				}
 				else if ((item.StateImageIndex == 1) || ((item.StateImageIndex == 2) && !modKey))
@@ -1849,7 +1924,7 @@ namespace Depressurizer
 					Category cat = item.Tag as Category;
 					if (cat != null)
 					{
-						RemoveCategoryFromSelectedGames(cat);
+						QuickRemoveCategoryFromSelectedGames(cat);
 					}
 				}
 			}

--- a/Source/Depressurizer/MainForm.cs
+++ b/Source/Depressurizer/MainForm.cs
@@ -258,12 +258,17 @@ namespace Depressurizer
 
 		private static ListViewItem CreateCategoryListViewItem(Category category)
 		{
-			return new ListViewItem(string.Format(CultureInfo.InvariantCulture, "{0} ({1})", category.Name, category.Count))
+			return new ListViewItem(CategoryListViewItemText(category))
 			{
 				Tag = category,
 				Name = category.Name
 			};
 		}
+
+		private static string CategoryListViewItemText(Category category)
+		{
+			return string.Format(CultureInfo.InvariantCulture, "{0} ({1})", category.Name, category.Count);
+        }
 
 		private void AddCategoryToSelectedGames(Category category, bool forceClearOthers)
 		{

--- a/Source/Depressurizer/MainForm.cs
+++ b/Source/Depressurizer/MainForm.cs
@@ -195,6 +195,11 @@ namespace Depressurizer
 
 		#region Methods
 
+		/// <summary>
+		/// Provides the display text for a category entry in the left hand pane.
+		/// </summary>
+		/// <param name="category">Category to get the display text of</param>
+		/// <returns></returns>
 		private static string CategoryListViewItemText(Category category)
 		{
 			return string.Format(CultureInfo.InvariantCulture, "{0} ({1})", category.Name, category.Count);
@@ -364,6 +369,11 @@ namespace Depressurizer
 			}
 		}
 
+		/// <summary>
+		/// Ensures the context menu contains an entry to remove any category the given game is assigned to.
+		/// <para/>
+		/// Inserted entries will be placed at the end.
+		/// </summary>
 		private void AddRemoveCategoryContextMenu(GameInfo game)
 		{
 			foreach (Category c in game.Categories)
@@ -372,6 +382,12 @@ namespace Depressurizer
 			}
 		}
 
+        /// <summary>
+        /// Append an entry to the end of the context menu to remove the given category from the selected games.
+        /// <para/>
+        /// No-op if there is already a button for the category.
+        /// </summary>
+        /// <param name="c">Category to add item for</param>
 		private void AddRemoveCategoryContextMenu(Category c)
 		{
 			if (!contextGameRemCat.Items.ContainsKey(c.Name))
@@ -3379,6 +3395,19 @@ namespace Depressurizer
 			FilterGamelist(false);
 		}
 
+		/// <summary>
+		/// Removes the category from the selected games and updates the UI in place.
+		/// <para/>
+		/// In particular,
+		/// it repaints the changed games,
+		/// it updates the category count in the left-hand pane,
+		/// sets checks the category in the category checkbox list at the bottom,
+		/// and it inserts the "remove category" context menu and sorts said menu.
+		/// <para/>
+		/// The games will remain in the currently displayed list. Selection is preserved.
+		///
+		/// </summary>
+		/// <param name="category">Category to add to the selected games.</param>
 		private void QuickAddCategoryToSelectedGames(Category category)
 		{
 			if (lstGames.SelectedObjects.Count <= 0)
@@ -3412,6 +3441,19 @@ namespace Depressurizer
 			Cursor.Current = Cursors.Default;
 		}
 
+		/// <summary>
+		/// Removes the category from the selected games and updates the UI in place.
+		/// <para/>
+		/// In particular,
+		/// it repaints the changed games,
+		/// it updates the category count in the left-hand pane,
+		/// sets checks the category in the category checkbox list at the bottom,
+		/// and it inserts the "remove category" context menu and sorts said menu.
+		/// <para/>
+		/// The games will remain in the currently displayed list. Selection is preserved.
+		///
+		/// </summary>
+		/// <param name="category">Category to remove from the selected games.</param>
 		private void QuickRemoveCategoryFromSelectedGames(Category category)
 		{
 			if (lstGames.SelectedObjects.Count <= 0)
@@ -4099,6 +4141,10 @@ namespace Depressurizer
 			}
 		}
 
+		/// <summary>
+		/// Updates the category's count in-place in the left-hand pane.
+		/// </summary>
+		/// <param name="category">Category to update in left-hand pane</param>
 		private void UpdateCategoryCountInCategoryList(Category category)
 		{
 			foreach (ListViewItem item in lstCategories.Items)

--- a/Source/Depressurizer/MainForm.cs
+++ b/Source/Depressurizer/MainForm.cs
@@ -112,9 +112,6 @@ namespace Depressurizer
 
 		#region Public Properties
 
-		/// <summary>
-		///     Just checks to see if there is currently a profile loaded
-		/// </summary>
 		public bool ProfileLoaded => CurrentProfile != null;
 
 		#endregion
@@ -147,10 +144,6 @@ namespace Depressurizer
 
 		#region Public Methods and Operators
 
-		/// <summary>
-		///     Adds a string to the status builder
-		/// </summary>
-		/// <param name="s"></param>
 		public void AddStatus(string s)
 		{
 			_statusBuilder.Append(s);
@@ -186,17 +179,11 @@ namespace Depressurizer
 			SaveDatabase(true);
 		}
 
-		/// <summary>
-		///     Empties the status builder
-		/// </summary>
 		public void ClearStatus()
 		{
 			_statusBuilder.Clear();
 		}
 
-		/// <summary>
-		///     Sets the status text to the builder text, and clear the builder text.
-		/// </summary>
 		public void FlushStatus()
 		{
 			mlblStatusMsg.Font = new Font("Arial", 9);
@@ -397,10 +384,6 @@ namespace Depressurizer
 			}
 		}
 
-
-		/// <summary>
-		///     Adds a new game. Displays the game dialog to the user.
-		/// </summary>
 		private void AddGame()
 		{
 			DlgGame dlg = new DlgGame(CurrentProfile.GameData, null);
@@ -541,10 +524,6 @@ namespace Depressurizer
 			OnViewChange();
 		}
 
-		/// <summary>
-		///     Assigns the given favorite state to all selected items in the game list.
-		/// </summary>
-		/// <param name="fav">True to turn fav on, false to turn it off.</param>
 		private void AssignFavoriteToSelectedGames(bool fav)
 		{
 			if (lstGames.SelectedObjects.Count > 0)
@@ -562,10 +541,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Add or remove the hidden attribute to the selected games
-		/// </summary>
-		/// <param name="hidden">Whether the games should be hidden</param>
 		private void AssignHiddenToSelectedGames(bool hidden)
 		{
 			if (lstGames.SelectedObjects.Count > 0)
@@ -583,11 +558,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Autocategorizes a set of games.
-		/// </summary>
-		/// <param name="selectedOnly">If true, runs on the selected games, otherwise, runs on all games.</param>
-		/// <param name="autoCat">The autocat object to use.</param>
 		private void Autocategorize(bool selectedOnly, AutoCat autoCat, bool scrape = true, bool refresh = true)
 		{
 			if (autoCat == null)
@@ -762,9 +732,6 @@ namespace Depressurizer
 			return count;
 		}
 
-		/// <summary>
-		///     Renames all games with names from the database.
-		/// </summary>
 		private void AutonameAll()
 		{
 			DialogResult res = MessageBox.Show(GlobalStrings.MainForm_OverwriteExistingNames, GlobalStrings.MainForm_Overwrite, MessageBoxButtons.YesNoCancel, MessageBoxIcon.Question, MessageBoxDefaultButton.Button2);
@@ -813,15 +780,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     jpodadera. Recursive function to reload resources of new language for a control and its childs
-		/// </summary>
-		/// <param name="c"></param>
-		/// Control to reload resources
-		/// <param name="resources"></param>
-		/// Resource manager
-		/// <param name="newCulture"></param>
-		/// Culture of language to load
 		private void ChangeLanguageControls(Control c, ComponentResourceManager resources, CultureInfo newCulture)
 		{
 			if (c != null)
@@ -859,15 +817,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     jpodadera. Recursive function to reload resources of new language for a menu item and its childs
-		/// </summary>
-		/// <param name="item"></param>
-		/// Item menu to reload resources
-		/// <param name="resources"></param>
-		/// Resource manager
-		/// <param name="newCulture"></param>
-		/// Culture of language to load
 		private void ChangeLanguageToolStripItems(ToolStripItem item, ComponentResourceManager resources, CultureInfo newCulture)
 		{
 			if (item != null)
@@ -1142,11 +1091,6 @@ namespace Depressurizer
 			lstCategories.Sort();
 		}
 
-		/// <summary>
-		///     Creates a new category, first prompting the user for the name to use. If the name is not valid or in use, displays
-		///     a notification.
-		/// </summary>
-		/// <returns>The category that was added, or null if the operation was canceled or failed.</returns>
 		private Category CreateCategory()
 		{
 			if (!ProfileLoaded)
@@ -1173,9 +1117,6 @@ namespace Depressurizer
 			return null;
 		}
 
-		/// <summary>
-		///     Prompts user to create a new profile.
-		/// </summary>
 		private void CreateProfile()
 		{
 			DlgProfile dlg = new DlgProfile();
@@ -1210,9 +1151,6 @@ namespace Depressurizer
 			OnProfileChange();
 		}
 
-		/// <summary>
-		///     Deletes the selected categories and updates the UI. Prompts user for confirmation.
-		/// </summary>
 		private void DeleteCategory()
 		{
 			List<Category> toDelete = new List<Category>();
@@ -1279,9 +1217,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Creates an Edit AutoCats dialog for the user
-		/// </summary>
 		private void EditAutoCats(AutoCat selected)
 		{
 			if (!ProfileLoaded)
@@ -1301,9 +1236,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Edits the first selected game. Displays game dialog.
-		/// </summary>
 		private void EditGame()
 		{
 			if (lstGames.SelectedObjects.Count > 0)
@@ -1321,10 +1253,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Prompts the user to modify the currently loaded profile. If there isn't one, asks if the user would like to create
-		///     one.
-		/// </summary>
 		private void EditProfile()
 		{
 			if (ProfileLoaded)
@@ -1371,9 +1299,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Attempts to export steam categories
-		/// </summary>
 		private void ExportConfig()
 		{
 			if (CurrentProfile != null)
@@ -1392,9 +1317,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Completely repopulates the category list and combobox. Maintains selection on both.
-		/// </summary>
 		private void FillAllCategoryLists()
 		{
 			Cursor = Cursors.WaitCursor;
@@ -1649,9 +1571,6 @@ namespace Depressurizer
 			lstCategories.EndUpdate();
 		}
 
-		/// <summary>
-		///     Completely re-populates the game list.
-		/// </summary>
 		private void FillGameList()
 		{
 			Cursor = Cursors.WaitCursor;
@@ -1792,9 +1711,6 @@ namespace Depressurizer
 			FlushStatus();
 		}
 
-		/// <summary>
-		///     Completely regenerates both the category and game lists
-		/// </summary>
 		private void FullListRefresh()
 		{
 			FillAllCategoryLists();
@@ -1930,9 +1846,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Attempts to import steam categories
-		/// </summary>
 		private void ImportConfig()
 		{
 			if (!ProfileLoaded)
@@ -2559,10 +2472,6 @@ namespace Depressurizer
 			contextAutoCat.Renderer = new MyRenderer();
 		}
 
-		/// <summary>
-		///     Launchs selected game
-		///     <param name="g">Game to launch</param>
-		/// </summary>
 		private void LaunchGame(GameInfo g)
 		{
 			if (g != null)
@@ -2572,9 +2481,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Prompts user for a profile file to load, then loads it.
-		/// </summary>
 		private void LoadProfile()
 		{
 			if (!CheckForUnsaved())
@@ -2595,11 +2501,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Loads the given profile file.
-		/// </summary>
-		/// <param name="path"></param>
-		/// <param name="checkForChanges"></param>
 		private void LoadProfile(string path, bool checkForChanges = true)
 		{
 			Cursor = Cursors.WaitCursor;
@@ -3118,20 +3019,12 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Sets the unsaved changes flag to the given value and takes the requisite UI updating action
-		/// </summary>
-		/// <param name="changes"></param>
 		private void MakeChange(bool changes)
 		{
 			_unsavedChanges = changes;
 			UpdateTitle();
 		}
 
-		/// <summary>
-		///     Saves a Steam configuration file. Asks the user to select the file to save as.
-		/// </summary>
-		/// <returns>True if save was completed, false otherwise</returns>
 		private void ManualExportConfig()
 		{
 			if (CurrentProfile == null)
@@ -3531,9 +3424,6 @@ namespace Depressurizer
 			lstCategories.Sort();
 		}
 
-		/// <summary>
-		///     Updates UI after a profile is created, loaded, modified or closed.
-		/// </summary>
 		private void OnProfileChange()
 		{
 			bool enable = ProfileLoaded;
@@ -3565,9 +3455,6 @@ namespace Depressurizer
 			FilterGamelist(false);
 		}
 
-		/// <summary>
-		///     Rebuild all the list view items in the gamelist, preserving as much state as is possible
-		/// </summary>
 		private void RebuildGamelist()
 		{
 			lstGames.BuildList();
@@ -3615,9 +3502,6 @@ namespace Depressurizer
 			Cursor.Current = Cursors.Default;
 		}
 
-		/// <summary>
-		///     Removes any categories with no games assigned.
-		/// </summary>
 		private void RemoveEmptyCats()
 		{
 			int count = CurrentProfile.GameData.RemoveEmptyCategories();
@@ -3625,9 +3509,6 @@ namespace Depressurizer
 			FillAllCategoryLists();
 		}
 
-		/// <summary>
-		///     Removes all selected games. Prompts for confirmation.
-		/// </summary>
 		private void RemoveGames()
 		{
 			int selectCount = lstGames.SelectedObjects.Count;
@@ -3673,11 +3554,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Renames the given category. Prompts user for a new name. Updates UI. Will display an error if the rename fails.
-		/// </summary>
-		/// <param name="c">Category to rename</param>
-		/// <returns>True if category was renamed, false otherwise.</returns>
 		private bool RenameCategory()
 		{
 			if (lstCategories.SelectedItems.Count > 0)
@@ -3873,12 +3749,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Saves profile data to a file and performs any related tasks. This is the main saving function, all saves go through
-		///     this function.
-		/// </summary>
-		/// <param name="path">Path to save to. If null, just saves profile to its current path.</param>
-		/// <returns>True if successful, false if there is a failure</returns>
 		private bool SaveProfile(string path = null)
 		{
 			if (!ProfileLoaded)
@@ -3919,9 +3789,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Prompts user for a file location and saves profile
-		/// </summary>
 		private void SaveProfileAs()
 		{
 			if (!ProfileLoaded)
@@ -4210,10 +4077,6 @@ namespace Depressurizer
 			return g.ContainsCategory(category);
 		}
 
-		/// <summary>
-		///     Unloads the current profile or game list, making sure the user gets the option to save any changes.
-		/// </summary>
-		/// <returns>True if there is now no loaded profile, false otherwise.</returns>
 		private void Unload()
 		{
 			if (!CheckForUnsaved())
@@ -4323,9 +4186,6 @@ namespace Depressurizer
 			mbtnCatRename.Enabled = (category != null) && !((CurrentProfile != null) && (category == CurrentProfile.GameData.FavoriteCategory));
 		}
 
-		/// <summary>
-		///     Updates enabled states for all game and category buttons
-		/// </summary>
 		private void UpdateEnabledStatesForGames()
 		{
 			bool gamesSelected = lstGames.SelectedObjects.Count > 0;
@@ -4377,9 +4237,6 @@ namespace Depressurizer
 			lstMultiCat.EndUpdate();
 		}
 
-		/// <summary>
-		///     Updates the game list for the loaded profile.
-		/// </summary>
 		private void UpdateLibrary()
 		{
 			if (CurrentProfile == null)
@@ -4466,18 +4323,12 @@ namespace Depressurizer
 			Cursor = Cursors.Default;
 		}
 
-		/// <summary>
-		///     Updates the text displaying the number of items in the game list
-		/// </summary>
 		private void UpdateSelectedStatusText()
 		{
 			mlblStatusSelection.Font = new Font("Arial", 9);
 			mlblStatusSelection.Text = string.Format(CultureInfo.CurrentCulture, GlobalStrings.MainForm_SelectedDisplayed, lstGames.SelectedObjects.Count, lstGames.GetItemCount());
 		}
 
-		/// <summary>
-		///     Updates the window title.
-		/// </summary>
 		private void UpdateTitle()
 		{
 			StringBuilder sb = new StringBuilder("Depressurizer");
@@ -4508,9 +4359,6 @@ namespace Depressurizer
 			}
 		}
 
-		/// <summary>
-		///     Update UI to match current state of the SingleCatMode setting
-		/// </summary>
 		private void UpdateUiForSingleCat()
 		{
 			bool sCat = Settings.SingleCatMode;
@@ -4518,12 +4366,6 @@ namespace Depressurizer
 			UpdateTitle();
 		}
 
-		/// <summary>
-		///     Checks to see if a category name is valid. Does not make sure it isn't already in use. If the name is not valid,
-		///     displays a warning.
-		/// </summary>
-		/// <param name="name">Name to check</param>
-		/// <returns>True if valid, false otherwise</returns>
 		private bool ValidateCategoryName(string name)
 		{
 			if (string.IsNullOrEmpty(name))

--- a/Source/Depressurizer/MainForm.cs
+++ b/Source/Depressurizer/MainForm.cs
@@ -195,6 +195,11 @@ namespace Depressurizer
 
 		#region Methods
 
+		private static string CategoryListViewItemText(Category category)
+		{
+			return string.Format(CultureInfo.InvariantCulture, "{0} ({1})", category.Name, category.Count);
+		}
+
 		private static void CheckForDepressurizerUpdates()
 		{
 			string rawJson;
@@ -252,11 +257,6 @@ namespace Depressurizer
 			};
 		}
 
-		private static string CategoryListViewItemText(Category category)
-		{
-			return string.Format(CultureInfo.InvariantCulture, "{0} ({1})", category.Name, category.Count);
-        }
-
 		private void AddCategoryToSelectedGames(Category category, bool forceClearOthers)
 		{
 			if (lstGames.SelectedObjects.Count <= 0)
@@ -306,82 +306,6 @@ namespace Depressurizer
 			MakeChange(true);
 
 			Cursor.Current = Cursors.Default;
-		}
-
-		private void QuickAddCategoryToSelectedGames(Category category)
-		{
-			if (lstGames.SelectedObjects.Count <= 0)
-			{
-				return;
-			}
-
-			Cursor.Current = Cursors.WaitCursor;
-
-			foreach (GameInfo gameInfo in _tlstGames.SelectedObjects)
-			{
-				if (gameInfo == null)
-				{
-					continue;
-				}
-
-
-				gameInfo.AddCategory(category);
-			}
-			lstGames.RefreshSelectedObjects();
-
-			UpdateCategoryCountInCategoryList(category);
-
-			AddRemoveCategoryContextMenu(category);
-			ResortToolStripItemCollection(contextGameRemCat.Items);
-
-			lstMultiCat.Items[category.Name].Checked = true;
-
-			MakeChange(true);
-
-			Cursor.Current = Cursors.Default;
-		}
-
-		private void QuickRemoveCategoryFromSelectedGames(Category category)
-		{
-			if (lstGames.SelectedObjects.Count <= 0)
-			{
-				return;
-			}
-
-			Cursor.Current = Cursors.WaitCursor;
-
-			foreach (GameInfo gameInfo in _tlstGames.SelectedObjects)
-			{
-				if (gameInfo == null)
-				{
-					continue;
-				}
-
-
-				gameInfo.RemoveCategory(category);
-			}
-			lstGames.RefreshSelectedObjects();
-
-			UpdateCategoryCountInCategoryList(category);
-
-			contextGameRemCat.Items.RemoveByKey(category.Name);
-			lstMultiCat.Items[category.Name].Checked = false;
-
-
-			MakeChange(true);
-
-			Cursor.Current = Cursors.Default;
-		}
-
-		private void UpdateCategoryCountInCategoryList(Category category)
-		{
-			foreach (ListViewItem item in lstCategories.Items)
-			{
-				if (Object.ReferenceEquals(item.Tag, category))
-				{
-					item.Text = CategoryListViewItemText(category);
-				}
-			}
 		}
 
 		private void AddGame()
@@ -3455,6 +3379,70 @@ namespace Depressurizer
 			FilterGamelist(false);
 		}
 
+		private void QuickAddCategoryToSelectedGames(Category category)
+		{
+			if (lstGames.SelectedObjects.Count <= 0)
+			{
+				return;
+			}
+
+			Cursor.Current = Cursors.WaitCursor;
+
+			foreach (GameInfo gameInfo in _tlstGames.SelectedObjects)
+			{
+				if (gameInfo == null)
+				{
+					continue;
+				}
+
+				gameInfo.AddCategory(category);
+			}
+
+			lstGames.RefreshSelectedObjects();
+
+			UpdateCategoryCountInCategoryList(category);
+
+			AddRemoveCategoryContextMenu(category);
+			ResortToolStripItemCollection(contextGameRemCat.Items);
+
+			lstMultiCat.Items[category.Name].Checked = true;
+
+			MakeChange(true);
+
+			Cursor.Current = Cursors.Default;
+		}
+
+		private void QuickRemoveCategoryFromSelectedGames(Category category)
+		{
+			if (lstGames.SelectedObjects.Count <= 0)
+			{
+				return;
+			}
+
+			Cursor.Current = Cursors.WaitCursor;
+
+			foreach (GameInfo gameInfo in _tlstGames.SelectedObjects)
+			{
+				if (gameInfo == null)
+				{
+					continue;
+				}
+
+				gameInfo.RemoveCategory(category);
+			}
+
+			lstGames.RefreshSelectedObjects();
+
+			UpdateCategoryCountInCategoryList(category);
+
+			contextGameRemCat.Items.RemoveByKey(category.Name);
+			lstMultiCat.Items[category.Name].Checked = false;
+
+			MakeChange(true);
+
+			Cursor.Current = Cursors.Default;
+		}
+
 		private void RebuildGamelist()
 		{
 			lstGames.BuildList();
@@ -4107,6 +4095,17 @@ namespace Depressurizer
 				{
 					ClearStatus();
 					FlushStatus();
+				}
+			}
+		}
+
+		private void UpdateCategoryCountInCategoryList(Category category)
+		{
+			foreach (ListViewItem item in lstCategories.Items)
+			{
+				if (ReferenceEquals(item.Tag, category))
+				{
+					item.Text = CategoryListViewItemText(category);
 				}
 			}
 		}

--- a/Source/Depressurizer/MainForm.cs
+++ b/Source/Depressurizer/MainForm.cs
@@ -196,13 +196,24 @@ namespace Depressurizer
 		#region Methods
 
 		/// <summary>
-		/// Provides the display text for a category entry in the left hand pane.
+		///     Creates the  text for a Category entry.
 		/// </summary>
 		/// <param name="category">Category to get the display text of</param>
-		/// <returns></returns>
+		/// <returns>Display text for the provided Category information</returns>
 		private static string CategoryListViewItemText(Category category)
 		{
-			return string.Format(CultureInfo.InvariantCulture, "{0} ({1})", category.Name, category.Count);
+			return CategoryListViewItemText(category.Name, category.Count);
+		}
+
+		/// <summary>
+		///     Creates the  text for a Category entry.
+		/// </summary>
+		/// <param name="categoryName">Name of the Category</param>
+		/// <param name="categoryCount">Count of the Category</param>
+		/// <returns>Display text for the provided Category information</returns>
+		private static string CategoryListViewItemText(string categoryName, int categoryCount)
+		{
+			return string.Format(CultureInfo.InvariantCulture, "{0} ({1})", categoryName, categoryCount);
 		}
 
 		private static void CheckForDepressurizerUpdates()
@@ -299,7 +310,7 @@ namespace Depressurizer
 				FilterGamelist(false);
 			}
 
-			if (lstCategories.SelectedItems[0].Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Uncategorized))
+			if (lstCategories.SelectedItems[0].Tag.ToString() == Resources.Category_Uncategorized)
 			{
 				FilterGamelist(false);
 			}
@@ -370,33 +381,45 @@ namespace Depressurizer
 		}
 
 		/// <summary>
-		/// Ensures the context menu contains an entry to remove any category the given game is assigned to.
-		/// <para/>
-		/// Inserted entries will be placed at the end.
+		///     Ensures the context menu contains an entry to remove any category the given game is assigned to.
+		///     <para />
+		///     Inserted entries will be placed at the end.
 		/// </summary>
 		private void AddRemoveCategoryContextMenu(GameInfo game)
 		{
-			foreach (Category c in game.Categories)
+			if ((game == null) || (game.Categories == null))
 			{
-				AddRemoveCategoryContextMenu(c);
+				return;
+			}
+
+			foreach (Category category in game.Categories)
+			{
+				AddRemoveCategoryContextMenu(category);
 			}
 		}
 
-        /// <summary>
-        /// Append an entry to the end of the context menu to remove the given category from the selected games.
-        /// <para/>
-        /// No-op if there is already a button for the category.
-        /// </summary>
-        /// <param name="c">Category to add item for</param>
-		private void AddRemoveCategoryContextMenu(Category c)
+		/// <summary>
+		///     Append an entry to the end of the context menu to remove the given category from the selected games.
+		///     <para />
+		///     No-op if there is already a button for the category.
+		/// </summary>
+		/// <param name="category">Category to add item for</param>
+		private void AddRemoveCategoryContextMenu(Category category)
 		{
-			if (!contextGameRemCat.Items.ContainsKey(c.Name))
+			if (category == null)
 			{
-				ToolStripItem item = contextGameRemCat.Items.Add(c.Name);
-				item.Tag = c;
-				item.Name = c.Name;
-				item.Click += contextGameRemCat_Category_Click;
+				return;
 			}
+
+			if (contextGameRemCat.Items.ContainsKey(category.Name))
+			{
+				return;
+			}
+
+			ToolStripItem item = contextGameRemCat.Items.Add(category.Name);
+			item.Tag = category;
+			item.Name = category.Name;
+			item.Click += contextGameRemCat_Category_Click;
 		}
 
 		private void ApplyFilter(Filter f)
@@ -412,27 +435,27 @@ namespace Depressurizer
 			// load new Advanced settings
 			foreach (ListViewItem i in lstCategories.Items)
 			{
-				if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Games))
+				if (i.Tag.ToString() == Resources.Category_Games)
 				{
 					i.StateImageIndex = f.Game;
 					_advFilter.Game = f.Game;
 				}
-				else if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Software))
+				else if (i.Tag.ToString() == Resources.Category_Software)
 				{
 					i.StateImageIndex = f.Software;
 					_advFilter.Software = f.Software;
 				}
-				else if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Uncategorized))
+				else if (i.Tag.ToString() == Resources.Category_Uncategorized)
 				{
 					i.StateImageIndex = f.Uncategorized;
 					_advFilter.Uncategorized = f.Uncategorized;
 				}
-				else if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Hidden))
+				else if (i.Tag.ToString() == Resources.Category_Hidden)
 				{
 					i.StateImageIndex = f.Hidden;
 					_advFilter.Hidden = f.Hidden;
 				}
-				else if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_VR))
+				else if (i.Tag.ToString() == Resources.Category_VR)
 				{
 					i.StateImageIndex = f.VR;
 					_advFilter.VR = f.VR;
@@ -1424,56 +1447,56 @@ namespace Depressurizer
 			if (!AdvancedCategoryFilter)
 			{
 				// <All>
-				listViewItem = new ListViewItem(string.Format(CultureInfo.CurrentCulture, "<{0}> ({1})", Resources.Category_All, games + software))
+				listViewItem = new ListViewItem(CategoryListViewItemText(Resources.Category_All, games + software))
 				{
-					Tag = string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_All),
-					Name = string.Format(CultureInfo.CurrentUICulture, "<{0}>", Resources.Category_All)
+					Tag = Resources.Category_All,
+					Name = Resources.Category_All
 				};
 
 				lstCategories.Items.Add(listViewItem);
 			}
 
 			// <Games>
-			listViewItem = new ListViewItem(string.Format(CultureInfo.CurrentCulture, "<{0}> ({1})", Resources.Category_Games, games))
+			listViewItem = new ListViewItem(CategoryListViewItemText(Resources.Category_Games, games))
 			{
-				Tag = string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Games),
-				Name = string.Format(CultureInfo.CurrentUICulture, "<{0}>", Resources.Category_Games)
+				Tag = Resources.Category_Games,
+				Name = Resources.Category_Games
 			};
 
 			lstCategories.Items.Add(listViewItem);
 
 			// <Software>
-			listViewItem = new ListViewItem(string.Format(CultureInfo.CurrentCulture, "<{0}> ({1})", Resources.Category_Software, software))
+			listViewItem = new ListViewItem(CategoryListViewItemText(Resources.Category_Software, software))
 			{
-				Tag = string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Software),
-				Name = string.Format(CultureInfo.CurrentUICulture, "<{0}>", Resources.Category_Software)
+				Tag = Resources.Category_Software,
+				Name = Resources.Category_Software
 			};
 
 			lstCategories.Items.Add(listViewItem);
 
 			// <Uncategorized>
-			listViewItem = new ListViewItem(string.Format(CultureInfo.CurrentCulture, "<{0}> ({1})", Resources.Category_Uncategorized, uncategorized))
+			listViewItem = new ListViewItem(CategoryListViewItemText(Resources.Category_Uncategorized, uncategorized))
 			{
-				Tag = string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Uncategorized),
-				Name = string.Format(CultureInfo.CurrentUICulture, "<{0}>", Resources.Category_Uncategorized)
+				Tag = Resources.Category_Uncategorized,
+				Name = Resources.Category_Uncategorized
 			};
 
 			lstCategories.Items.Add(listViewItem);
 
 			// <Hidden>
-			listViewItem = new ListViewItem(string.Format(CultureInfo.CurrentCulture, "<{0}> ({1})", Resources.Category_Hidden, hidden))
+			listViewItem = new ListViewItem(CategoryListViewItemText(Resources.Category_Hidden, hidden))
 			{
-				Tag = string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Hidden),
-				Name = string.Format(CultureInfo.CurrentUICulture, "<{0}>", Resources.Category_Hidden)
+				Tag = Resources.Category_Hidden,
+				Name = Resources.Category_Hidden
 			};
 
 			lstCategories.Items.Add(listViewItem);
 
 			// <VR>
-			listViewItem = new ListViewItem(string.Format(CultureInfo.CurrentCulture, "<{0}> ({1})", Resources.Category_VR, vr))
+			listViewItem = new ListViewItem(CategoryListViewItemText(Resources.Category_VR, vr))
 			{
-				Tag = string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_VR),
-				Name = string.Format(CultureInfo.CurrentUICulture, "<{0}>", Resources.Category_VR)
+				Tag = Resources.Category_VR,
+				Name = Resources.Category_VR
 			};
 
 			lstCategories.Items.Add(listViewItem);
@@ -1681,23 +1704,23 @@ namespace Depressurizer
 				i.StateImageIndex += reverse ? -1 : 1;
 			}
 
-			if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Games))
+			if (i.Tag.ToString() == Resources.Category_Games)
 			{
 				_advFilter.Game = i.StateImageIndex;
 			}
-			else if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Software))
+			else if (i.Tag.ToString() == Resources.Category_Software)
 			{
 				_advFilter.Software = i.StateImageIndex;
 			}
-			else if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Uncategorized))
+			else if (i.Tag.ToString() == Resources.Category_Uncategorized)
 			{
 				_advFilter.Uncategorized = i.StateImageIndex;
 			}
-			else if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Hidden))
+			else if (i.Tag.ToString() == Resources.Category_Hidden)
 			{
 				_advFilter.Hidden = i.StateImageIndex;
 			}
-			else if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_VR))
+			else if (i.Tag.ToString() == Resources.Category_VR)
 			{
 				_advFilter.VR = i.StateImageIndex;
 			}
@@ -1848,7 +1871,7 @@ namespace Depressurizer
 					return string.Empty;
 				}
 
-				return ((GameInfo) g).GetCatString(string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Uncategorized));
+				return ((GameInfo) g).GetCatString(Resources.Category_Uncategorized);
 			};
 
 			colFavorite.AspectGetter = delegate(object g)
@@ -2524,14 +2547,14 @@ namespace Depressurizer
 					FilterGamelist(false);
 					MakeChange(true);
 				}
-				else if ((string) dropItem.Tag == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Uncategorized))
+				else if ((string) dropItem.Tag == Resources.Category_Uncategorized)
 				{
 					CurrentProfile.GameData.ClearGameCategories((int[]) e.Data.GetData(typeof(int[])), true);
 					FillCategoryList();
 					FilterGamelist(false);
 					MakeChange(true);
 				}
-				else if ((string) dropItem.Tag == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Hidden))
+				else if ((string) dropItem.Tag == Resources.Category_Hidden)
 				{
 					CurrentProfile.GameData.HideGames((int[]) e.Data.GetData(typeof(int[])), true);
 					FillCategoryList();
@@ -3396,16 +3419,15 @@ namespace Depressurizer
 		}
 
 		/// <summary>
-		/// Removes the category from the selected games and updates the UI in place.
-		/// <para/>
-		/// In particular,
-		/// it repaints the changed games,
-		/// it updates the category count in the left-hand pane,
-		/// sets checks the category in the category checkbox list at the bottom,
-		/// and it inserts the "remove category" context menu and sorts said menu.
-		/// <para/>
-		/// The games will remain in the currently displayed list. Selection is preserved.
-		///
+		///     Removes the category from the selected games and updates the UI in place.
+		///     <para />
+		///     In particular,
+		///     it repaints the changed games,
+		///     it updates the category count in the left-hand pane,
+		///     sets checks the category in the category checkbox list at the bottom,
+		///     and it inserts the "remove category" context menu and sorts said menu.
+		///     <para />
+		///     The games will remain in the currently displayed list. Selection is preserved.
 		/// </summary>
 		/// <param name="category">Category to add to the selected games.</param>
 		private void QuickAddCategoryToSelectedGames(Category category)
@@ -3442,16 +3464,15 @@ namespace Depressurizer
 		}
 
 		/// <summary>
-		/// Removes the category from the selected games and updates the UI in place.
-		/// <para/>
-		/// In particular,
-		/// it repaints the changed games,
-		/// it updates the category count in the left-hand pane,
-		/// sets checks the category in the category checkbox list at the bottom,
-		/// and it inserts the "remove category" context menu and sorts said menu.
-		/// <para/>
-		/// The games will remain in the currently displayed list. Selection is preserved.
-		///
+		///     Removes the category from the selected games and updates the UI in place.
+		///     <para />
+		///     In particular,
+		///     it repaints the changed games,
+		///     it updates the category count in the left-hand pane,
+		///     sets checks the category in the category checkbox list at the bottom,
+		///     and it inserts the "remove category" context menu and sorts said menu.
+		///     <para />
+		///     The games will remain in the currently displayed list. Selection is preserved.
 		/// </summary>
 		/// <param name="category">Category to remove from the selected games.</param>
 		private void QuickRemoveCategoryFromSelectedGames(Category category)
@@ -3500,36 +3521,6 @@ namespace Depressurizer
 				cboFilter.DisplayMember = "Name";
 				cboFilter.Text = "";
 			}
-		}
-
-		private void RemoveCategoryFromSelectedGames(Category category)
-		{
-			if (lstGames.SelectedObjects.Count <= 0)
-			{
-				return;
-			}
-
-			Cursor.Current = Cursors.WaitCursor;
-
-			foreach (GameInfo gameInfo in _tlstGames.SelectedObjects)
-			{
-				gameInfo.RemoveCategory(category);
-			}
-
-			FillAllCategoryLists();
-
-			if (lstCategories.SelectedItems[0].Tag is Category selectedCategory && (selectedCategory == category))
-			{
-				FilterGamelist(false);
-			}
-			else
-			{
-				FilterGamelist(true);
-			}
-
-			MakeChange(true);
-
-			Cursor.Current = Cursors.Default;
 		}
 
 		private void RemoveEmptyCats()
@@ -3967,23 +3958,23 @@ namespace Depressurizer
 		{
 			i.StateImageIndex = state;
 
-			if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Games))
+			if (i.Tag.ToString() == Resources.Category_Games)
 			{
 				_advFilter.Game = state;
 			}
-			else if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Software))
+			else if (i.Tag.ToString() == Resources.Category_Software)
 			{
 				_advFilter.Software = state;
 			}
-			else if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Uncategorized))
+			else if (i.Tag.ToString() == Resources.Category_Uncategorized)
 			{
 				_advFilter.Uncategorized = state;
 			}
-			else if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Hidden))
+			else if (i.Tag.ToString() == Resources.Category_Hidden)
 			{
 				_advFilter.Hidden = state;
 			}
-			else if (i.Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_VR))
+			else if (i.Tag.ToString() == Resources.Category_VR)
 			{
 				_advFilter.VR = state;
 			}
@@ -4060,35 +4051,35 @@ namespace Depressurizer
 
 			if (g.Hidden)
 			{
-				return lstCategories.SelectedItems[0].Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Hidden);
+				return lstCategories.SelectedItems[0].Tag.ToString() == Resources.Category_Hidden;
 			}
 
 			// <All>
-			if (lstCategories.SelectedItems[0].Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_All))
+			if (lstCategories.SelectedItems[0].Tag.ToString() == Resources.Category_All)
 			{
 				return true;
 			}
 
 			// <Games>
-			if (lstCategories.SelectedItems[0].Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Games))
+			if (lstCategories.SelectedItems[0].Tag.ToString() == Resources.Category_Games)
 			{
 				return Database.Games.ContainsKey(g.Id) && (Database.Games.First(a => a.Key == g.Id).Value.AppType == AppType.Game);
 			}
 
 			// <Software>
-			if (lstCategories.SelectedItems[0].Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Software))
+			if (lstCategories.SelectedItems[0].Tag.ToString() == Resources.Category_Software)
 			{
 				return Database.Games.ContainsKey(g.Id) && (Database.Games.First(a => a.Key == g.Id).Value.AppType == AppType.Application);
 			}
 
 			// <Uncategorized>
-			if (lstCategories.SelectedItems[0].Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Uncategorized))
+			if (lstCategories.SelectedItems[0].Tag.ToString() == Resources.Category_Uncategorized)
 			{
 				return g.Categories.Count == 0;
 			}
 
 			// <VR>
-			if (lstCategories.SelectedItems[0].Tag.ToString() == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_VR))
+			if (lstCategories.SelectedItems[0].Tag.ToString() == Resources.Category_VR)
 			{
 				return Database.SupportsVR(g.Id);
 			}
@@ -4099,7 +4090,7 @@ namespace Depressurizer
 			}
 
 			// <Favorite>
-			if (category.Name == string.Format(CultureInfo.CurrentCulture, "<{0}>", Resources.Category_Favorite))
+			if (category.Name == Resources.Category_Favorite)
 			{
 				return g.IsFavorite();
 			}
@@ -4142,16 +4133,21 @@ namespace Depressurizer
 		}
 
 		/// <summary>
-		/// Updates the category's count in-place in the left-hand pane.
+		///     Updates the category's count in-place in the left-hand pane.
 		/// </summary>
 		/// <param name="category">Category to update in left-hand pane</param>
 		private void UpdateCategoryCountInCategoryList(Category category)
 		{
-			foreach (ListViewItem item in lstCategories.Items)
+			if (category == null)
 			{
-				if (ReferenceEquals(item.Tag, category))
+				return;
+			}
+
+			foreach (ListViewItem listViewItem in lstCategories.Items)
+			{
+				if (ReferenceEquals(listViewItem.Tag, category))
 				{
-					item.Text = CategoryListViewItemText(category);
+					listViewItem.Text = CategoryListViewItemText(category);
 				}
 			}
 		}

--- a/Source/Depressurizer/Models/ListCategoriesComparer.cs
+++ b/Source/Depressurizer/Models/ListCategoriesComparer.cs
@@ -84,13 +84,13 @@ namespace Depressurizer.Models
 			// Handle special categories
 			List<string> specialCategories = new List<string>
 			{
-				$"<{Resources.Category_All}>",
-				$"<{Resources.Category_Games}>",
-				$"<{Resources.Category_Software}>",
-				$"<{Resources.Category_Uncategorized}>",
-				$"<{Resources.Category_Hidden}>",
-				$"<{Resources.Category_VR}>",
-				$"<{Resources.Category_Favorite}>"
+				Resources.Category_All,
+				Resources.Category_Games,
+				Resources.Category_Software,
+				Resources.Category_Uncategorized,
+				Resources.Category_Hidden,
+				Resources.Category_VR,
+				Resources.Category_Favorite
 			};
 
 			foreach (string category in specialCategories)

--- a/Source/Depressurizer/Properties/Resources.Designer.cs
+++ b/Source/Depressurizer/Properties/Resources.Designer.cs
@@ -70,7 +70,7 @@ namespace Depressurizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to All.
+        ///   Looks up a localized string similar to &lt;All&gt;.
         /// </summary>
         internal static string Category_All {
             get {
@@ -79,7 +79,7 @@ namespace Depressurizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Favorite.
+        ///   Looks up a localized string similar to &lt;Favorite&gt;.
         /// </summary>
         internal static string Category_Favorite {
             get {
@@ -88,7 +88,7 @@ namespace Depressurizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Games.
+        ///   Looks up a localized string similar to &lt;Games&gt;.
         /// </summary>
         internal static string Category_Games {
             get {
@@ -97,7 +97,7 @@ namespace Depressurizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hidden.
+        ///   Looks up a localized string similar to &lt;Hidden&gt;.
         /// </summary>
         internal static string Category_Hidden {
             get {
@@ -106,7 +106,7 @@ namespace Depressurizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Software.
+        ///   Looks up a localized string similar to &lt;Software&gt;.
         /// </summary>
         internal static string Category_Software {
             get {
@@ -115,7 +115,7 @@ namespace Depressurizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Uncategorized.
+        ///   Looks up a localized string similar to &lt;Uncategorized&gt;.
         /// </summary>
         internal static string Category_Uncategorized {
             get {
@@ -124,7 +124,7 @@ namespace Depressurizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to VR.
+        ///   Looks up a localized string similar to &lt;VR&gt;.
         /// </summary>
         internal static string Category_VR {
             get {

--- a/Source/Depressurizer/Properties/Resources.resx
+++ b/Source/Depressurizer/Properties/Resources.resx
@@ -121,25 +121,25 @@
     <value>Applying Data</value>
   </data>
   <data name="Category_All" xml:space="preserve">
-    <value>All</value>
+    <value>&lt;All&gt;</value>
   </data>
   <data name="Category_Favorite" xml:space="preserve">
-    <value>Favorite</value>
+    <value>&lt;Favorite&gt;</value>
   </data>
   <data name="Category_Games" xml:space="preserve">
-    <value>Games</value>
+    <value>&lt;Games&gt;</value>
   </data>
   <data name="Category_Hidden" xml:space="preserve">
-    <value>Hidden</value>
+    <value>&lt;Hidden&gt;</value>
   </data>
   <data name="Category_Software" xml:space="preserve">
-    <value>Software</value>
+    <value>&lt;Software&gt;</value>
   </data>
   <data name="Category_Uncategorized" xml:space="preserve">
-    <value>Uncategorized</value>
+    <value>&lt;Uncategorized&gt;</value>
   </data>
   <data name="Category_VR" xml:space="preserve">
-    <value>VR</value>
+    <value>&lt;VR&gt;</value>
   </data>
   <data name="Error_DepressurizerUpdate" xml:space="preserve">
     <value>Error encountered while checking for Depressurizer updates:</value>


### PR DESCRIPTION
When assigning games to categories (via the checkboxes or rightclick -> add/remove), the entire UI gets rebuilt.

This changes the following: 

When having games selected and assigning categories either through the context menu or the category list at the bottom

- the delay has been reduced to a minimum :tada:
- the left hand side list is no longer rebuilt, instead the game count is updated in place
- as a consequence, vertical scroll position is always retained
- the list of categories at the bottom is no longer cleared and rebuilt, checkboxes are updated in-place
- as a consequence, horizontal scroll position is always retained 🍾 
- the "categories" column in the games list is updated in place
- the right-click menu -> remove categories is updated in place mostly

This leads to an additional change in behavior which I have not addressed. When using the left hand side to filter by category, removing that category from a game does not immediately remove it from the list. Similarly, when browsing "<Uncategorized>" and adding a category to a game, the game(s) will not disappear immediately. They only disappear when re-selecting the category filter on the left.

Personally, I like this new behavior, because it makes it easier to go through a list and assign/remove categories until I'm done.
