### PR TITLE
Improve context menu scrolling

### DIFF
--- a/Source/Depressurizer/Depressurizer.csproj
+++ b/Source/Depressurizer/Depressurizer.csproj
@@ -242,6 +242,7 @@
     </Compile>
     <Compile Include="GameList.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="Helpers\DropDownMenuScrollWheelHandler.cs" />
     <Compile Include="Models\CategorySort.cs" />
     <Compile Include="Models\CommaClusterStrategy.cs" />
     <Compile Include="Database.cs" />

--- a/Source/Depressurizer/Helpers/DropdownMenuScrollWheelHandler.cs
+++ b/Source/Depressurizer/Helpers/DropdownMenuScrollWheelHandler.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Reflection;
+using System.Windows.Forms;
+
+namespace Depressurizer.Helpers
+{
+	/// <summary>
+	/// Allows mouse wheel scrolling inside ToolStripDropDowns, e.g. all context menus.
+	/// Adapted from: https://stackoverflow.com/a/27390000/383124
+	/// </summary>
+	internal static class DropdownMenuScrollWheelHandler
+	{
+		#region Fields
+
+		private static MessageFilterImplementation _messageFilter;
+
+		#endregion
+
+		#region Methods
+
+		/// <summary>
+		/// Installs a global message filter to allow all ToolStripDropDowns to scroll via mouse wheel.
+		/// <para/>
+		/// No-op if already enabled.
+		/// </summary>
+		public static void Enable()
+		{
+			if (_messageFilter == null)
+			{
+				_messageFilter = new MessageFilterImplementation();
+				Application.AddMessageFilter(_messageFilter);
+			}
+		}
+
+		/// <summary>
+		/// No-op if disabled/never enabled.
+		/// </summary>
+		public static void Disable()
+		{
+			if (_messageFilter != null)
+			{
+				Application.RemoveMessageFilter(_messageFilter);
+				_messageFilter = null;
+			}
+		}
+
+		#endregion
+
+		#region Implementation
+
+		private class MessageFilterImplementation : IMessageFilter
+		{
+			#region WM Constants
+
+			private const int WM_MOUSEMOVE = 0x200;
+			private const int WM_MOUSEWHEEL = 0x20A;
+
+			#endregion
+
+			#region Fields
+
+			/// <summary>
+			/// Helper to access non-public <a href="https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/ToolStrip.cs">ScrollInternal</a> method.
+			/// </summary>
+			private static readonly Action<ToolStripDropDown, int> ScrollInternal =
+				(Action<ToolStripDropDown, int>) Delegate.CreateDelegate(typeof(Action<ToolStripDropDown, int>),
+					typeof(ToolStripDropDown).GetMethod("ScrollInternal",
+						BindingFlags.NonPublic | BindingFlags.Instance));
+
+			/// <summary>
+			/// Window handle the mouse moved over last.
+			/// </summary>
+			private IntPtr _activeHwnd;
+
+			/// <summary>
+			/// ToolStripDropdown beneath mouse, or null if the mouse is over a different kind of control.
+			/// </summary>
+			private ToolStripDropDown _activeMenu;
+
+			#endregion
+
+			/// <summary>
+			/// On mouse move, check whether the mouse moved to a different control. If it is a ToolStripDropDown, save the handle, otherwise, clear the handle. Then, the mouse move is processed as usual.
+			/// <para/>
+			/// On mouse wheel, scroll the drop down menu if the mouse is inside one. Then, filter out the message.
+			/// </summary>
+			/// <returns>Whether the message is filtered out, i.e. suppressed.</returns>
+			public bool PreFilterMessage(ref Message m)
+			{
+				if (m.Msg == WM_MOUSEMOVE && _activeHwnd != m.HWnd)
+				{
+					_activeHwnd = m.HWnd;
+					_activeMenu = Control.FromHandle(m.HWnd) as ToolStripDropDown;
+				}
+				else if (m.Msg == WM_MOUSEWHEEL && _activeMenu != null)
+				{
+					int delta = (short) (ushort) ((uint) (ulong) m.WParam >> 16);
+					HandleDelta(_activeMenu, delta);
+					return true;
+				}
+
+				return false;
+			}
+
+			private static void HandleDelta(ToolStripDropDown ts, int delta)
+			{
+				if (ts.Items.Count == 0) return;
+				var firstItem = ts.Items[0];
+				var lastItem = ts.Items[ts.Items.Count - 1];
+				if (lastItem.Bounds.Bottom < ts.Height && firstItem.Bounds.Top > 0) return;
+				// Controls the scroll speed and fix direction
+				delta = delta / -2;
+				if (delta < 0 && firstItem.Bounds.Top - delta > 9)
+					delta = firstItem.Bounds.Top - 9;
+				else if (delta > 0 && delta > lastItem.Bounds.Bottom - ts.Height + 9)
+					delta = lastItem.Bounds.Bottom - ts.Height + 9;
+
+				if (delta != 0) ScrollInternal(ts, delta);
+			}
+		}
+
+		#endregion
+	}
+}

--- a/Source/Depressurizer/Helpers/DropdownMenuScrollWheelHandler.cs
+++ b/Source/Depressurizer/Helpers/DropdownMenuScrollWheelHandler.cs
@@ -1,39 +1,45 @@
-﻿using System;
+﻿#region LICENSE
+
+//     This file (DropDownMenuScrollWheelHandler.cs) is part of Depressurizer.
+//     Copyright (C) 2018  Martijn Vegter
+// 
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+// 
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+// 
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#endregion
+
+using System;
 using System.Reflection;
 using System.Windows.Forms;
 
 namespace Depressurizer.Helpers
 {
 	/// <summary>
-	/// Allows mouse wheel scrolling inside ToolStripDropDowns, e.g. all context menus.
-	/// Adapted from: https://stackoverflow.com/a/27390000/383124
+	///     Allows mouse wheel scrolling inside ToolStripDropDowns, e.g. all context menus.
+	///     Adapted from: https://stackoverflow.com/a/27390000/383124
 	/// </summary>
 	internal static class DropdownMenuScrollWheelHandler
 	{
-		#region Fields
+		#region Static Fields
 
 		private static MessageFilterImplementation _messageFilter;
 
 		#endregion
 
-		#region Methods
+		#region Public Methods and Operators
 
 		/// <summary>
-		/// Installs a global message filter to allow all ToolStripDropDowns to scroll via mouse wheel.
-		/// <para/>
-		/// No-op if already enabled.
-		/// </summary>
-		public static void Enable()
-		{
-			if (_messageFilter == null)
-			{
-				_messageFilter = new MessageFilterImplementation();
-				Application.AddMessageFilter(_messageFilter);
-			}
-		}
-
-		/// <summary>
-		/// No-op if disabled/never enabled.
+		///     No-op if disabled/never enabled.
 		/// </summary>
 		public static void Disable()
 		{
@@ -44,55 +50,73 @@ namespace Depressurizer.Helpers
 			}
 		}
 
-		#endregion
+		/// <summary>
+		///     Installs a global message filter to allow all ToolStripDropDowns to scroll via mouse wheel.
+		///     <para />
+		///     No-op if already enabled.
+		/// </summary>
+		public static void Enable()
+		{
+			if (_messageFilter == null)
+			{
+				_messageFilter = new MessageFilterImplementation();
+				Application.AddMessageFilter(_messageFilter);
+			}
+		}
 
-		#region Implementation
+		#endregion
 
 		private class MessageFilterImplementation : IMessageFilter
 		{
-			#region WM Constants
+			#region Constants
 
 			private const int WM_MOUSEMOVE = 0x200;
 			private const int WM_MOUSEWHEEL = 0x20A;
 
 			#endregion
 
+			#region Static Fields
+
+			/// <summary>
+			///     Helper to access non-public
+			///     <a href="https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/ToolStrip.cs">ScrollInternal</a>
+			///     method.
+			/// </summary>
+			private static readonly Action<ToolStripDropDown, int> ScrollInternal = (Action<ToolStripDropDown, int>) Delegate.CreateDelegate(typeof(Action<ToolStripDropDown, int>), typeof(ToolStripDropDown).GetMethod("ScrollInternal", BindingFlags.NonPublic | BindingFlags.Instance));
+
+			#endregion
+
 			#region Fields
 
 			/// <summary>
-			/// Helper to access non-public <a href="https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/ToolStrip.cs">ScrollInternal</a> method.
-			/// </summary>
-			private static readonly Action<ToolStripDropDown, int> ScrollInternal =
-				(Action<ToolStripDropDown, int>) Delegate.CreateDelegate(typeof(Action<ToolStripDropDown, int>),
-					typeof(ToolStripDropDown).GetMethod("ScrollInternal",
-						BindingFlags.NonPublic | BindingFlags.Instance));
-
-			/// <summary>
-			/// Window handle the mouse moved over last.
+			///     Window handle the mouse moved over last.
 			/// </summary>
 			private IntPtr _activeHwnd;
 
 			/// <summary>
-			/// ToolStripDropdown beneath mouse, or null if the mouse is over a different kind of control.
+			///     ToolStripDropdown beneath mouse, or null if the mouse is over a different kind of control.
 			/// </summary>
 			private ToolStripDropDown _activeMenu;
 
 			#endregion
 
+			#region Public Methods and Operators
+
 			/// <summary>
-			/// On mouse move, check whether the mouse moved to a different control. If it is a ToolStripDropDown, save the handle, otherwise, clear the handle. Then, the mouse move is processed as usual.
-			/// <para/>
-			/// On mouse wheel, scroll the drop down menu if the mouse is inside one. Then, filter out the message.
+			///     On mouse move, check whether the mouse moved to a different control. If it is a ToolStripDropDown, save the handle,
+			///     otherwise, clear the handle. Then, the mouse move is processed as usual.
+			///     <para />
+			///     On mouse wheel, scroll the drop down menu if the mouse is inside one. Then, filter out the message.
 			/// </summary>
 			/// <returns>Whether the message is filtered out, i.e. suppressed.</returns>
 			public bool PreFilterMessage(ref Message m)
 			{
-				if (m.Msg == WM_MOUSEMOVE && _activeHwnd != m.HWnd)
+				if ((m.Msg == WM_MOUSEMOVE) && (_activeHwnd != m.HWnd))
 				{
 					_activeHwnd = m.HWnd;
 					_activeMenu = Control.FromHandle(m.HWnd) as ToolStripDropDown;
 				}
-				else if (m.Msg == WM_MOUSEWHEEL && _activeMenu != null)
+				else if ((m.Msg == WM_MOUSEWHEEL) && (_activeMenu != null))
 				{
 					int delta = (short) (ushort) ((uint) (ulong) m.WParam >> 16);
 					HandleDelta(_activeMenu, delta);
@@ -102,23 +126,42 @@ namespace Depressurizer.Helpers
 				return false;
 			}
 
+			#endregion
+
+			#region Methods
+
 			private static void HandleDelta(ToolStripDropDown ts, int delta)
 			{
-				if (ts.Items.Count == 0) return;
-				var firstItem = ts.Items[0];
-				var lastItem = ts.Items[ts.Items.Count - 1];
-				if (lastItem.Bounds.Bottom < ts.Height && firstItem.Bounds.Top > 0) return;
+				if (ts.Items.Count == 0)
+				{
+					return;
+				}
+
+				ToolStripItem firstItem = ts.Items[0];
+				ToolStripItem lastItem = ts.Items[ts.Items.Count - 1];
+				if ((lastItem.Bounds.Bottom < ts.Height) && (firstItem.Bounds.Top > 0))
+				{
+					return;
+				}
+
 				// Controls the scroll speed and fix direction
 				delta = delta / -2;
-				if (delta < 0 && firstItem.Bounds.Top - delta > 9)
+				if ((delta < 0) && ((firstItem.Bounds.Top - delta) > 9))
+				{
 					delta = firstItem.Bounds.Top - 9;
-				else if (delta > 0 && delta > lastItem.Bounds.Bottom - ts.Height + 9)
-					delta = lastItem.Bounds.Bottom - ts.Height + 9;
+				}
+				else if ((delta > 0) && (delta > ((lastItem.Bounds.Bottom - ts.Height) + 9)))
+				{
+					delta = (lastItem.Bounds.Bottom - ts.Height) + 9;
+				}
 
-				if (delta != 0) ScrollInternal(ts, delta);
+				if (delta != 0)
+				{
+					ScrollInternal(ts, delta);
+				}
 			}
-		}
 
-		#endregion
+			#endregion
+		}
 	}
 }

--- a/Source/Depressurizer/MainForm.cs
+++ b/Source/Depressurizer/MainForm.cs
@@ -35,6 +35,7 @@ using System.Threading;
 using System.Windows.Forms;
 using BrightIdeasSoftware;
 using Depressurizer.Dialogs;
+using Depressurizer.Helpers;
 using Depressurizer.Models;
 using Depressurizer.Properties;
 using DepressurizerCore;
@@ -44,7 +45,7 @@ using MaterialSkin;
 using MaterialSkin.Controls;
 using Newtonsoft.Json.Linq;
 using Rallion;
-using DropdownMenuScrollWheelHandler = Depressurizer.Helpers.DropdownMenuScrollWheelHandler;
+using Utility = DepressurizerCore.Helpers.Utility;
 
 namespace Depressurizer
 {
@@ -3768,7 +3769,7 @@ namespace Depressurizer
 				}
 				else
 				{
-					if (!autoCat.Selected && !@group)
+					if (!autoCat.Selected && !group)
 					{
 						continue;
 					}

--- a/Source/Depressurizer/MainForm.cs
+++ b/Source/Depressurizer/MainForm.cs
@@ -44,6 +44,7 @@ using MaterialSkin;
 using MaterialSkin.Controls;
 using Newtonsoft.Json.Linq;
 using Rallion;
+using DropdownMenuScrollWheelHandler = Depressurizer.Helpers.DropdownMenuScrollWheelHandler;
 
 namespace Depressurizer
 {
@@ -52,10 +53,6 @@ namespace Depressurizer
 		#region Constants
 
 		private const string AdvancedFilter = "ADVANCED_FILTER";
-
-		private const string BigDown = "{DOWN},{DOWN},{DOWN},{DOWN},{DOWN},{DOWN},{DOWN},{DOWN},{DOWN},{DOWN}";
-
-		private const string BigUp = "{UP},{UP},{UP},{UP},{UP},{UP},{UP},{UP},{UP},{UP}";
 
 		private const string EarlyAccess = "Early Access";
 
@@ -1672,8 +1669,8 @@ namespace Depressurizer
 
 		private void FormMain_Load(object sender, EventArgs e)
 		{
-			// allow mousewheel scrolling for Add Category submenu.  Send 10 UP/DOWN per wheel click.
-			contextGame.MouseWheel += HandleMouseWheel;
+			// allow mousewheel scrolling context menus, e.g. for Add Category submenu.
+			DropdownMenuScrollWheelHandler.Enable();
 
 			ttHelp.Ext_SetToolTip(mchkAdvancedCategories, GlobalStrings.MainForm_Help_AdvancedCategories);
 
@@ -1839,14 +1836,6 @@ namespace Depressurizer
 			if (updateView)
 			{
 				OnViewChange();
-			}
-		}
-
-		private void HandleMouseWheel(object sender, MouseEventArgs e)
-		{
-			if (contextGame.IsDropDown)
-			{
-				SendKeys.SendWait(e.Delta > 0 ? BigUp : BigDown);
 			}
 		}
 


### PR DESCRIPTION
Scrolling inside a context menu no longer sends arrow-up/down keypresses. Instead, mouse wheel messages are intercepted and the menu is actually *scrolled* beneath the mouse wheel.

Previously, moving the mouse only slightly while "scrolling" would re-focus the item beneath the mouse. With this new method, scrolling works as expected.