### PR TITLE
Travis-CI OS X support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,18 @@ env:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     - NET_CORE_VERSION: netcoreapp2.2
 
+matrix:
+  # We can use fast finish, as we don't need to wait for allow_failures builds to mark build as success
+  fast_finish: true
+  include:
+    - os: linux
+      # Ref: https://docs.travis-ci.com/user/reference/xenial
+      dist: xenial
+    - os: osx
+      # Ref: https://docs.travis-ci.com/user/reference/osx
+      dotnet: 2.2.101 # For OSX, we need absolute dotnet version until https://github.com/dotnet/core-setup/issues/4187 is resolved
+      osx_image: xcode10.1
+
 script:
   - dotnet build ./src/Depressurizer.Tests/Depressurizer.Tests.csproj -c "$CONFIGURATION" -f "$NET_CORE_VERSION"
   - dotnet test ./src/Depressurizer.Tests/Depressurizer.Tests.csproj -c "$CONFIGURATION" -f "$NET_CORE_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,22 @@
 language: csharp
 solution: src/Depressurizer.sln
 
-dotnet: 2.1.502
+git:
+  depth: 10
+
+# Use latest images for building: https://blog.travis-ci.com/2017-12-01-new-update-schedule-for-linux-build-images
+group: travis_latest
+
+dotnet: 2.2
 mono: none
 
+env:
+  global:
+    - CONFIGURATION: Release
+    - DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+    - NET_CORE_VERSION: netcoreapp2.2
+
 script:
-  - dotnet build ./src/Depressurizer.Tests/Depressurizer.Tests.csproj
-  - dotnet test ./src/Depressurizer.Tests/Depressurizer.Tests.csproj
+  - dotnet build ./src/Depressurizer.Tests/Depressurizer.Tests.csproj -c "$CONFIGURATION" -f "$NET_CORE_VERSION"
+  - dotnet test ./src/Depressurizer.Tests/Depressurizer.Tests.csproj -c "$CONFIGURATION" -f "$NET_CORE_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ git:
 # Use latest images for building: https://blog.travis-ci.com/2017-12-01-new-update-schedule-for-linux-build-images
 group: travis_latest
 
-dotnet: 2.2
+dotnet: 2.1.502
 mono: none
 
 env:
@@ -15,7 +15,7 @@ env:
     - CONFIGURATION: Release
     - DOTNET_CLI_TELEMETRY_OPTOUT: 1
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-    - NET_CORE_VERSION: netcoreapp2.2
+    - NET_CORE_VERSION: netcoreapp2.1
 
 matrix:
   # We can use fast finish, as we don't need to wait for allow_failures builds to mark build as success
@@ -26,7 +26,7 @@ matrix:
       dist: xenial
     - os: osx
       # Ref: https://docs.travis-ci.com/user/reference/osx
-      dotnet: 2.2.101 # For OSX, we need absolute dotnet version until https://github.com/dotnet/core-setup/issues/4187 is resolved
+      dotnet: 2.1.502 # For OSX, we need absolute dotnet version until https://github.com/dotnet/core-setup/issues/4187 is resolved
       osx_image: xcode10.1
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ mono: none
 
 env:
   global:
-    - CONFIGURATION: Release
+    - CONFIGURATION: Debug
     - DOTNET_CLI_TELEMETRY_OPTOUT: 1
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
     - NET_CORE_VERSION: netcoreapp2.1


### PR DESCRIPTION
Travis tests on Linux and OS X.
AppVeyor tests on Windows.