### PR TITLE
Adjusting category list on shortcut integration

### DIFF
--- a/src/Depressurizer/GameList.cs
+++ b/src/Depressurizer/GameList.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Globalization;
@@ -745,6 +745,8 @@ namespace Depressurizer
                     {
                         Games.Remove(g);
                     }
+
+                    RemoveEmptyCategories();
 
                     // Load launch IDs
                     LoadShortcutLaunchIds(steamId, out StringDictionary launchIds);


### PR DESCRIPTION
fixes #116, fixes #115 

Fixes a problem where the category list would contain duplicates of any categories that were assigned exclusively to shortcuts.