### PR TITLE
Save Database.json with gzip

### DIFF
--- a/src/Depressurizer.Core/Helpers/Locations.cs
+++ b/src/Depressurizer.Core/Helpers/Locations.cs
@@ -18,6 +18,7 @@ namespace Depressurizer.Core.Helpers
             ///     Default database file location.
             /// </summary>
             public static string Database => "database.json";
+
             /// <summary>
             ///     Default database (gzipped) file location.
             /// </summary>

--- a/src/Depressurizer.Core/Helpers/Locations.cs
+++ b/src/Depressurizer.Core/Helpers/Locations.cs
@@ -22,7 +22,7 @@ namespace Depressurizer.Core.Helpers
             /// <summary>
             ///     Default database (gzipped) file location.
             /// </summary>
-            public static string DatabaseGzip => "database.json.gz";
+            public static string DatabaseGzip => Database + ".gz";
 
             /// <summary>
             ///     Default log file location.

--- a/src/Depressurizer.Core/Helpers/Locations.cs
+++ b/src/Depressurizer.Core/Helpers/Locations.cs
@@ -18,6 +18,10 @@ namespace Depressurizer.Core.Helpers
             ///     Default database file location.
             /// </summary>
             public static string Database => "database.json";
+            /// <summary>
+            ///     Default database (gzipped) file location.
+            /// </summary>
+            public static string DatabaseGzip => "database.json.gz";
 
             /// <summary>
             ///     Default log file location.

--- a/src/Depressurizer/AutomaticModeForm.cs
+++ b/src/Depressurizer/AutomaticModeForm.cs
@@ -263,9 +263,9 @@ namespace Depressurizer
             try
             {
                 Database.Reset();
-                if (File.Exists(Locations.File.Database))
+                if (Database.getExistsDatabasePath() != "")
                 {
-                    Database.Load(Locations.File.Database);
+                    Database.Load();
                     success = true;
                 }
                 else
@@ -493,7 +493,7 @@ namespace Depressurizer
             Write("Saving database...");
             try
             {
-                Database.Save(Locations.File.Database);
+                Database.Save(Locations.File.DatabaseGzip);
                 success = true;
             }
             catch (Exception e)

--- a/src/Depressurizer/AutomaticModeForm.cs
+++ b/src/Depressurizer/AutomaticModeForm.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 using System.Xml.XPath;

--- a/src/Depressurizer/AutomaticModeForm.cs
+++ b/src/Depressurizer/AutomaticModeForm.cs
@@ -262,7 +262,7 @@ namespace Depressurizer
             try
             {
                 Database.Reset();
-                if (Database.getExistsDatabasePath() != "")
+                if (!string.IsNullOrWhiteSpace(Database.getExistsDatabasePath()))
                 {
                     Database.Load();
                     success = true;

--- a/src/Depressurizer/DBEdit/DBEditDlg.cs
+++ b/src/Depressurizer/DBEdit/DBEditDlg.cs
@@ -743,6 +743,10 @@ namespace Depressurizer
         {
             Cursor = Cursors.WaitCursor;
 
+            if (path == Locations.File.Database)
+            {
+                path = Locations.File.DatabaseGzip;
+            }
             try
             {
                 Database.Save(path);

--- a/src/Depressurizer/DBEdit/DBEditDlg.cs
+++ b/src/Depressurizer/DBEdit/DBEditDlg.cs
@@ -747,6 +747,7 @@ namespace Depressurizer
             {
                 path = Locations.File.DatabaseGzip;
             }
+
             try
             {
                 Database.Save(path);

--- a/src/Depressurizer/Database.cs
+++ b/src/Depressurizer/Database.cs
@@ -331,6 +331,26 @@ namespace Depressurizer
             Save();
         }
 
+        public bool CheckDatabaseToGzip(string path, string gzPath) // TODO: testcase
+        {
+            if (File.Exists(path) && !File.Exists(gzPath))
+            {
+                using (FileStream fs = new FileStream(gzPath, FileMode.Create, FileAccess.Write))
+                using (GZipStream compressor = new GZipStream(fs, CompressionLevel.Fastest))
+                using (StreamWriter gzWriter = new StreamWriter(compressor))
+
+                using (StreamReader jsonFile = File.OpenText(path))
+                {
+                    gzWriter.Write(jsonFile.ReadToEnd());
+                }
+
+                // Delete old database file in the future, if works fine.
+                return true;
+            }
+
+            return false;
+        }
+
         public void Clear()
         {
             DatabaseEntries.Clear();
@@ -440,6 +460,26 @@ namespace Depressurizer
             }
 
             return result;
+        }
+
+        public string getExistsDatabasePath(string custPath = "")
+        {
+            if (custPath != "" && File.Exists(custPath))
+            {
+                return custPath;
+            }
+
+            if (File.Exists(Locations.File.DatabaseGzip))
+            {
+                return Locations.File.DatabaseGzip;
+            }
+
+            if (File.Exists(Locations.File.Database))
+            {
+                return Locations.File.Database;
+            }
+
+            return "";
         }
 
         public SortedSet<string> GetFlagList(int appId)
@@ -575,37 +615,6 @@ namespace Depressurizer
             return entry.AppType == appType;
         }
 
-        public string getExistsDatabasePath(string custPath = "")
-        {
-            if (custPath != "" && File.Exists(custPath))
-                return custPath;
-            if (File.Exists(Locations.File.DatabaseGzip))
-                return Locations.File.DatabaseGzip;
-            if (File.Exists(Locations.File.Database))
-                return Locations.File.Database;
-            return "";
-        }
-
-
-
-        public bool CheckDatabaseToGzip(string path, string gzPath) // TODO: testcase
-        {
-            if (File.Exists(path) && !File.Exists(gzPath))
-            {
-                using (var fs = new FileStream(gzPath, FileMode.Create, FileAccess.Write))
-                using (var compressor = new GZipStream(fs, CompressionLevel.Fastest))
-                using (StreamWriter gzWriter = new StreamWriter(compressor))
-
-                using (StreamReader jsonFile = File.OpenText(path))
-                {
-                    gzWriter.Write(jsonFile.ReadToEnd());
-                }
-
-                // Delete old database file in the future, if works fine.
-                return true;
-            }
-            return false;
-        }
         public void Load()
         {
             CheckDatabaseToGzip(Locations.File.Database, Locations.File.DatabaseGzip);
@@ -626,8 +635,8 @@ namespace Depressurizer
             Stopwatch sw = new Stopwatch();
             sw.Start();
 
-            using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
-            using (var compressor = new GZipStream(fs, CompressionMode.Decompress))
+            using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (GZipStream compressor = new GZipStream(fs, CompressionMode.Decompress))
             using (StreamReader file = new StreamReader(compressor))
             {
                 JsonSerializer serializer = new JsonSerializer
@@ -672,8 +681,8 @@ namespace Depressurizer
             Stopwatch sw = new Stopwatch();
             sw.Start();
 
-            using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
-            using (var compressor = new GZipStream(fs, CompressionLevel.Fastest))
+            using (FileStream fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+            using (GZipStream compressor = new GZipStream(fs, CompressionLevel.Fastest))
             using (StreamWriter writer = new StreamWriter(compressor))
             {
                 JsonSerializer serializer = new JsonSerializer

--- a/src/Depressurizer/MainForm.cs
+++ b/src/Depressurizer/MainForm.cs
@@ -315,9 +315,11 @@ namespace Depressurizer
         {
             try
             {
-                if (File.Exists(Locations.File.Database))
+                Database.CheckDatabaseToGzip(Locations.File.Database, Locations.File.DatabaseGzip);
+                if (Database.getExistsDatabasePath() != "") // TODO: Convert to a public function
+
                 {
-                    Database.Load(Locations.File.Database);
+                    Database.Load();
                 }
                 else
                 {
@@ -3947,7 +3949,7 @@ namespace Depressurizer
         {
             try
             {
-                Database.Save(Locations.File.Database);
+                Database.Save(Locations.File.DatabaseGzip);
                 AddStatus(GlobalStrings.MainForm_Status_SavedDB);
             }
             catch (Exception e)


### PR DESCRIPTION
This closes #162.

This is a dirty implementation for #162, including hard-coded, non-reusable, no tests, etc. I originally planned it as new functions or a new user option.

I see that the compression ratio is about 4%, which is huge. Database writes are infrequent, but it seems to occur at startup, and perhaps multiple loops when a particular operation.

Thanks to https://stackoverflow.com/questions/32943899/can-i-decompress-and-deserialize-a-file-using-streams.
