### PR TITLE
Fix fetching error of the HLTB

### DIFF
--- a/src/Depressurizer/Database.cs
+++ b/src/Depressurizer/Database.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using Depressurizer.Core;
 using Depressurizer.Core.Enums;
 using Depressurizer.Core.Helpers;
@@ -732,6 +733,7 @@ namespace Depressurizer
 
             using (WebClient client = new WebClient())
             {
+                client.Encoding = Encoding.UTF8;
                 string result = client.DownloadString(Constants.HowLongToBeat);
 
                 if (result.Contains("An error has occurred."))


### PR DESCRIPTION
this data has unicode data in the `SteamName` and WebClient fetching
result would be broken.

here is a sample data (`result.Substring(61600, 30)`)
before:
`p Officer CG ?쏾huge Liang??與ゅ굇`

after:
` CG “Zhuge Liang” 横山光輝「三国志」タイア`

Resolve #142
Resolve #183 
