### PR TITLE
Allow changing case when renaming category

### DIFF
--- a/src/Depressurizer.Core/Interfaces/IGameList.cs
+++ b/src/Depressurizer.Core/Interfaces/IGameList.cs
@@ -1,7 +1,7 @@
-﻿using Depressurizer.Core.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Xml.XPath;
+using Depressurizer.Core.Models;
 
 namespace Depressurizer.Core.Interfaces
 {

--- a/src/Depressurizer.Core/Interfaces/IGameList.cs
+++ b/src/Depressurizer.Core/Interfaces/IGameList.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using Depressurizer.Core.Models;
+using System;
+using System.Collections.Generic;
 using System.Xml.XPath;
-using Depressurizer.Core.Models;
 
 namespace Depressurizer.Core.Interfaces
 {
@@ -24,7 +25,7 @@ namespace Depressurizer.Core.Interfaces
 
         #region Public Methods and Operators
 
-        Category AddCategory(string dialogValue);
+        Category AddCategory(string dialogValue, bool forModification = false);
 
         Filter AddFilter(string name);
 
@@ -32,7 +33,7 @@ namespace Depressurizer.Core.Interfaces
 
         void AddGameCategory(int[] appIds, Category category);
 
-        bool CategoryExists(string prefix);
+        bool CategoryExists(string prefix, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase);
 
         void ClearGameCategories(int appId, bool preserveFavorite);
 

--- a/src/Depressurizer.Core/Interfaces/IGameList.cs
+++ b/src/Depressurizer.Core/Interfaces/IGameList.cs
@@ -25,7 +25,7 @@ namespace Depressurizer.Core.Interfaces
 
         #region Public Methods and Operators
 
-        Category AddCategory(string dialogValue, bool forModification = false);
+        Category AddCategory(string name, bool forRename = false);
 
         Filter AddFilter(string name);
 
@@ -33,7 +33,7 @@ namespace Depressurizer.Core.Interfaces
 
         void AddGameCategory(int[] appIds, Category category);
 
-        bool CategoryExists(string prefix, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase);
+        bool CategoryExists(string name, StringComparison stringComparison = StringComparison.OrdinalIgnoreCase);
 
         void ClearGameCategories(int appId, bool preserveFavorite);
 

--- a/src/Depressurizer.Core/Models/GameList.cs
+++ b/src/Depressurizer.Core/Models/GameList.cs
@@ -635,7 +635,8 @@ namespace Depressurizer.Core.Models
         public int ImportSteamConfig(long steamId, SortedSet<int> ignore, bool includeShortcuts)
         {
             int result = 0;
-            if (Settings.ReadFromLevelDB) {
+            if (Settings.ReadFromLevelDB)
+            {
                 ImportSteamLevelDB(steamId);
             }
             else
@@ -652,8 +653,7 @@ namespace Depressurizer.Core.Models
             return result;
         }
 
-        private void ImportSteamLevelDB(long steamId)
-        {
+        private void ImportSteamLevelDB(long steamId) {
             Logger.Info("Importing from Steam LevelDB: {0}", steamId);
 
             SteamLevelDB levelDB = new SteamLevelDB(Steam.ToSteam3Id(steamId));

--- a/src/Depressurizer.Core/Models/GameList.cs
+++ b/src/Depressurizer.Core/Models/GameList.cs
@@ -1,6 +1,3 @@
-using Depressurizer.Core.Enums;
-using Depressurizer.Core.Helpers;
-using Depressurizer.Core.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -11,6 +8,9 @@ using System.Linq;
 using System.Net;
 using System.Xml;
 using System.Xml.XPath;
+using Depressurizer.Core.Enums;
+using Depressurizer.Core.Helpers;
+using Depressurizer.Core.Interfaces;
 using static Depressurizer.Core.Models.SteamLevelDB;
 using ValueType = Depressurizer.Core.Enums.ValueType;
 
@@ -635,8 +635,7 @@ namespace Depressurizer.Core.Models
         public int ImportSteamConfig(long steamId, SortedSet<int> ignore, bool includeShortcuts)
         {
             int result = 0;
-            if (Settings.ReadFromLevelDB)
-            {
+            if (Settings.ReadFromLevelDB) {
                 ImportSteamLevelDB(steamId);
             }
             else
@@ -666,7 +665,7 @@ namespace Depressurizer.Core.Models
                 SetGameCategories(game.Id, new List<Category>(), false);
             }
 
-            foreach (var collection in collections)
+            foreach(var collection in collections)
             {
                 foreach (var appId in collection.added)
                 {
@@ -942,13 +941,13 @@ namespace Depressurizer.Core.Models
             }
 
             foreach (GameInfo g in Games.Values)
-                foreach (Category c in g.Categories)
+            foreach (Category c in g.Categories)
+            {
+                if (counts.ContainsKey(c))
                 {
-                    if (counts.ContainsKey(c))
-                    {
-                        counts[c]++;
-                    }
+                    counts[c]++;
                 }
+            }
 
             int removed = 0;
             foreach (KeyValuePair<Category, int> pair in counts)


### PR DESCRIPTION
This closes #255.

When performing a rename operation, allow the new name to be the same as the old name if the case is different. Still do not allow duplicate categories to be created if the only difference between the names is the case.

https://github.com/Depressurizer/Depressurizer/assets/19156328/3404c147-ed08-4f76-a1f5-5375a6b12c96

