### PR TITLE
feat: wip hltb scraper service

### DIFF
--- a/src/Depressurizer.Core/Depressurizer.Core.csproj
+++ b/src/Depressurizer.Core/Depressurizer.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Platforms>AnyCPU</Platforms>
+	  <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -10,10 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.1.2" />
+    <PackageReference Include="Fastenshtein" Version="1.0.0.8" />
     <PackageReference Include="IronLeveldb" Version="1.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
     <PackageReference Include="newtonsoft.json" Version="13.0.1" />
+    <PackageReference Include="RandomUserAgent" Version="1.1.2" />
     <PackageReference Include="Sentry" Version="3.11.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Depressurizer.Core/Helpers/Constants.cs
+++ b/src/Depressurizer.Core/Helpers/Constants.cs
@@ -35,9 +35,9 @@ namespace Depressurizer.Core.Helpers
         public static string GetAppList => "https://api.steampowered.com/ISteamApps/GetAppList/v2";
 
         /// <summary>
-        ///     URL to the API page of HowLongToBeat.com.
+        ///     URL to the home page of HowLongToBeat.com.
         /// </summary>
-        public static Uri HowLongToBeat => new Uri("https://www.howlongtobeatsteam.com/api/games/library/cached/all");
+        public static Uri HowLongToBeat => new Uri("https://howlongtobeat.com");
 
         /// <summary>
         ///     Generic path to localconfig.vdf, must be formatted with the Steam installation path and the Steam ID.

--- a/src/Depressurizer.Core/Helpers/HowLongToBeatService.cs
+++ b/src/Depressurizer.Core/Helpers/HowLongToBeatService.cs
@@ -1,0 +1,510 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fastenshtein;
+using Newtonsoft.Json;
+using RandomUserAgent;
+using AngleSharp;
+using AngleSharp.Dom;
+
+namespace Depressurizer.Core.Helpers
+{
+    public class HowLongToBeatService
+    {
+        private HltbSearch hltb = new HltbSearch();
+
+        public HowLongToBeatService() { }
+
+        public async Task<HowLongToBeatEntry> Detail(string gameId, CancellationToken signal = default)
+        {
+            var detailPage = await hltb.DetailHtml(gameId, signal);
+            var entry = HowLongToBeatParser.ParseDetails(detailPage, gameId);
+            return entry;
+        }
+
+        public async Task<List<HowLongToBeatEntry>> Search(string query, CancellationToken signal = default)
+        {
+            var searchTerms = query.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+            var search = await hltb.Search(searchTerms, signal);
+            var hltbEntries = new List<HowLongToBeatEntry>();
+            foreach (var resultEntry in search.data)
+            {
+                hltbEntries.Add(new HowLongToBeatEntry(
+                    resultEntry.id.ToString(),
+                    resultEntry.name,
+                    "", // no description
+                    resultEntry.platforms != null ? resultEntry.platforms : new string[0],
+                    HltbSearch.IMAGE_URL + resultEntry.imageUrl,
+                    new List<string[]> { new string[] { "Main", "Main" }, new string[] { "Main + Extra", "Main + Extra" }, new string[] { "Completionist", "Completionist" } },
+                    (int)Math.Round(resultEntry.gameplayMain / 3600.0),
+                    (int)Math.Round(resultEntry.gameplayMainExtra / 3600.0),
+                    (int)Math.Round(resultEntry.gameplayCompletionist / 3600.0),
+                    CalcDistancePercentage(resultEntry.name, query),
+                    query
+                ));
+            }
+            return hltbEntries;
+        }
+
+        public static double CalcDistancePercentage(string text, string term)
+        {
+            var longer = text.ToLower().Trim();
+            var shorter = term.ToLower().Trim();
+            if (longer.Length < shorter.Length)
+            {
+                var temp = longer;
+                longer = shorter;
+                shorter = temp;
+            }
+            var longerLength = longer.Length;
+            if (longerLength == 0)
+                return 1.0;
+            var distance = Levenshtein.Distance(longer, shorter);
+            return Math.Round(((longerLength - distance) / (double)longerLength) * 100) / 100;
+        }
+    }
+
+    public class HowLongToBeatEntry
+    {
+        public readonly string[] PlayableOn;
+        public readonly string Id;
+        public readonly string Name;
+        public readonly string Description;
+        public readonly string[] Platforms;
+        public readonly string ImageUrl;
+        public readonly List<string[]> TimeLabels;
+        public readonly int GameplayMain;
+        public readonly int GameplayMainExtra;
+        public readonly int GameplayCompletionist;
+        public readonly double Similarity;
+        public readonly string SearchTerm;
+
+        public HowLongToBeatEntry(string id, string name, string description, string[] platforms, string imageUrl, List<string[]> timeLabels, int gameplayMain, int gameplayMainExtra, int gameplayCompletionist, double similarity, string searchTerm)
+        {
+            Id = id;
+            Name = name;
+            Description = description;
+            Platforms = platforms;
+            ImageUrl = imageUrl;
+            TimeLabels = timeLabels;
+            GameplayMain = gameplayMain;
+            GameplayMainExtra = gameplayMainExtra;
+            GameplayCompletionist = gameplayCompletionist;
+            Similarity = similarity;
+            SearchTerm = searchTerm;
+            PlayableOn = platforms; // Backward compatibility
+        }
+    }
+
+    public class HowLongToBeatParser
+    {
+        public static HowLongToBeatEntry ParseDetails(string html, string id)
+        {
+            var config = Configuration.Default;
+            var context = BrowsingContext.New(config);
+            var document = context.OpenAsync(req => req.Content(html)).Result;
+            var gameName = document.QuerySelector("[class*='GameHeader_profile_header_game__']")?.FirstChild?.TextContent.Trim();
+            var imageUrl = document.QuerySelector("[class*='GameHeader_game_image__'] img")?.GetAttribute("src");
+            var gameDescription = document.QuerySelector("[class*='GameSummary_large__']").TextContent;
+            var platforms = document.QuerySelectorAll("[class*='GameSummary_profile_info__']")
+                .Select(element => element.TextContent)
+                .FirstOrDefault(metaData => metaData.Contains("Platforms:"))?
+                .Replace("\n", "")
+                .Replace("Platforms:", "")
+                .Split(',')
+                .Select(data => data.Trim())
+                .ToArray() ?? new string[0];
+
+            var liElements = document.QuerySelectorAll("[class*='GameStats_game_times__'] li");
+            var timeLabels = new List<string[]>();
+            var gameplayMain = 0;
+            var gameplayMainExtra = 0;
+            var gameplayCompletionist = 0;
+
+            foreach (var liElement in liElements)
+            {
+                var type = liElement.QuerySelector("h4").TextContent;
+                var time = ParseTime(liElement.QuerySelector("h5").TextContent);
+                if (type.StartsWith("Main Story") || type.StartsWith("Single-Player") || type.StartsWith("Solo"))
+                {
+                    gameplayMain = time;
+                    timeLabels.Add(new string[] { "gameplayMain", type });
+                }
+                else if (type.StartsWith("Main + Sides") || type.StartsWith("Co-Op"))
+                {
+                    gameplayMainExtra = time;
+                    timeLabels.Add(new string[] { "gameplayMainExtra", type });
+                }
+                else if (type.StartsWith("Completionist") || type.StartsWith("Vs."))
+                {
+                    gameplayCompletionist = time;
+                    timeLabels.Add(new string[] { "gameplayComplete", type });
+                }
+            }
+
+            return new HowLongToBeatEntry(
+                id,
+                gameName,
+                gameDescription,
+                platforms,
+                imageUrl,
+                timeLabels,
+                gameplayMain,
+                gameplayMainExtra,
+                gameplayCompletionist,
+                1,
+                gameName
+            );
+        }
+
+        private static int ParseTime(string text)
+        {
+            if (text.StartsWith("--"))
+                return 0;
+            if (text.Contains(" - "))
+                return HandleRange(text);
+            return GetTime(text);
+        }
+
+        private static int HandleRange(string text)
+        {
+            var range = text.Split(new string[] { " - " }, StringSplitOptions.None);
+            var d = (GetTime(range[0]) + GetTime(range[1])) / 2;
+            return (int)d;
+        }
+
+        private static int GetTime(string text)
+        {
+            var timeUnit = text.Substring(text.IndexOf(' ') + 1).Trim();
+            if (timeUnit == "Mins")
+                return 1;
+            var time = text.Substring(0, text.IndexOf(' '));
+            if (time.Contains("½"))
+                return (int)(0.5 + int.Parse(time.Substring(0, text.IndexOf('½'))));
+            return int.Parse(time);
+        }
+    }
+
+
+    public class HltbSearch
+    {
+        public static string BASE_URL = "https://howlongtobeat.com/";
+        public static string DETAIL_URL = $"{BASE_URL}game?id=";
+        public static string SEARCH_URL = $"{BASE_URL}api/search";
+        public static string IMAGE_URL = $"{BASE_URL}games/";
+
+        private HttpClient httpClient;
+
+        public HltbSearch()
+        {
+            httpClient = new HttpClient();
+        }
+
+        public async Task<string> DetailHtml(string gameId, CancellationToken? cancellationToken = null)
+        {
+            try
+            {
+                string userAgent = RandomUa.RandomUserAgent;
+
+                // Create HttpRequestMessage with headers
+                var request = new HttpRequestMessage(HttpMethod.Get, $"{DETAIL_URL}{gameId}");
+                request.Headers.Add("User-Agent", userAgent);
+                request.Headers.Add("origin", "https://howlongtobeat.com");
+                request.Headers.Add("referer", "https://howlongtobeat.com");
+
+                // Send request
+                var response = await httpClient.SendAsync(request, cancellationToken ?? CancellationToken.None);
+
+                response.EnsureSuccessStatusCode();
+                return await response.Content.ReadAsStringAsync();
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new Exception("Failed to fetch game detail HTML.", ex);
+            }
+        }
+
+        public async Task<SearchResponse> Search(List<string> query, CancellationToken? cancellationToken = null)
+        {
+            var payload = new SearchPayload
+            {
+                searchType = "games",
+                searchTerms = query,
+                searchPage = 1,
+                size = 20,
+                searchOptions = new SearchOptions
+                {
+                    games = new GamesOptions
+                    {
+                        userId = 0,
+                        platform = "",
+                        sortCategory = "popular",
+                        rangeCategory = "main",
+                        rangeTime = new RangeTime { min = 0, max = 0 },
+                        gameplay = new GameplayOptions { perspective = "", flow = "", genre = "" },
+                        modifier = ""
+                    },
+                    users = new UsersOptions { sortCategory = "postcount" },
+                    filter = "",
+                    sort = 0,
+                    randomizer = 0
+                }
+            };
+
+            try
+            {
+                var jsonPayload = JsonConvert.SerializeObject(payload);
+                var content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
+
+                string userAgent = RandomUa.RandomUserAgent;
+                var request = new HttpRequestMessage(HttpMethod.Post, SEARCH_URL);
+                request.Content = content;
+                request.Headers.Add("User-Agent", userAgent);
+                request.Headers.Add("origin", "https://howlongtobeat.com");
+                request.Headers.Add("referer", "https://howlongtobeat.com");
+                var response = await httpClient.SendAsync(request, cancellationToken ?? CancellationToken.None);
+
+                response.EnsureSuccessStatusCode();
+                var jsonString = await response.Content.ReadAsStringAsync();
+                return JsonConvert.DeserializeObject<SearchResponse>(jsonString);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new Exception("Failed to perform search.", ex);
+            }
+        }
+    }
+
+    public class SearchResponse
+    {
+        public SearchEntry[] data { get; set; } 
+    }
+
+    public class SearchEntry
+    {
+        public string id { get; set; }
+        public string name { get; set; }
+        public string description { get; set; }
+        public string[] platforms { get; set; }
+        public string imageUrl { get; set; }
+        public string[][] timeLabels { get; set; }
+        public int gameplayMain { get; set; }
+        public int gameplayMainExtra { get; set; }
+        public int gameplayCompletionist { get; set; }
+        public double similarity { get; set; }
+        public string searchTerm { get; set; }
+        public string[] playableOn { get; set; }
+    }
+
+    public class SearchPayload
+    {
+        public string searchType { get; set; }
+        public List<string> searchTerms { get; set; }
+        public int searchPage { get; set; }
+        public int size { get; set; }
+        public SearchOptions searchOptions { get; set; }
+    }
+
+    public class SearchOptions
+    {
+        public GamesOptions games { get; set; }
+        public UsersOptions users { get; set; }
+        public string filter { get; set; }
+        public int sort { get; set; }
+        public int randomizer { get; set; }
+    }
+
+    public class GamesOptions
+    {
+        public int userId { get; set; }
+        public string platform { get; set; }
+        public string sortCategory { get; set; }
+        public string rangeCategory { get; set; }
+        public RangeTime rangeTime { get; set; }
+        public GameplayOptions gameplay { get; set; }
+        public string modifier { get; set; }
+    }
+
+    public class UsersOptions
+    {
+        public string sortCategory { get; set; }
+    }
+
+    public class RangeTime
+    {
+        public int min { get; set; }
+        public int max { get; set; }
+    }
+
+    public class GameplayOptions
+    {
+        public string perspective { get; set; }
+        public string flow { get; set; }
+        public string genre { get; set; }
+    }
+}
+
+
+
+/* [
+  HowLongToBeatEntry {
+    id: '36936',
+    name: 'Nioh',
+    description: '',
+    platforms: [ 'PC', 'PlayStation 4' ],
+    imageUrl: 'https://howlongtobeat.com/games/36936_Nioh.jpg',
+    timeLabels: [ [Array], [Array], [Array] ],
+    gameplayMain: 35,
+    gameplayMainExtra: 64,
+    gameplayCompletionist: 97,
+    similarity: 1,
+    searchTerm: 'Nioh',
+    playableOn: [ 'PC', 'PlayStation 4' ]
+  },
+  HowLongToBeatEntry {
+    id: '85713',
+    name: 'Nioh 2: Complete Edition',
+    description: '',
+    platforms: [ 'PC', 'PlayStation 4', 'PlayStation 5' ],
+    imageUrl: 'https://howlongtobeat.com/games/85713_Nioh_2_Complete_Edition.jpg',
+    timeLabels: [ [Array], [Array], [Array] ],
+    gameplayMain: 43,
+    gameplayMainExtra: 87,
+    gameplayCompletionist: 130,
+    similarity: 0.17,
+    searchTerm: 'Nioh',
+    playableOn: [ 'PC', 'PlayStation 4', 'PlayStation 5' ]
+  },
+  HowLongToBeatEntry {
+    id: '50419',
+    name: 'Nioh: Complete Edition',
+    description: '',
+    platforms: [ 'PC', 'PlayStation 4', 'PlayStation 5' ],
+    imageUrl: 'https://howlongtobeat.com/games/50419_Nioh_Complete_Edition.jpg',
+    timeLabels: [ [Array], [Array], [Array] ],
+    gameplayMain: 42,
+    gameplayMainExtra: 74,
+    gameplayCompletionist: 143,
+    similarity: 0.18,
+    searchTerm: 'Nioh',
+    playableOn: [ 'PC', 'PlayStation 4', 'PlayStation 5' ]
+  },
+  HowLongToBeatEntry {
+    id: '60877',
+    name: 'Nioh 2',
+    description: '',
+    platforms: [ 'PC', 'PlayStation 4' ],
+    imageUrl: 'https://howlongtobeat.com/games/60877_Nioh_2.jpg',
+    timeLabels: [ [Array], [Array], [Array] ],
+    gameplayMain: 45,
+    gameplayMainExtra: 73,
+    gameplayCompletionist: 106,
+    similarity: 0.67,
+    searchTerm: 'Nioh',
+    playableOn: [ 'PC', 'PlayStation 4' ]
+  },
+  HowLongToBeatEntry {
+    id: '84043',
+    name: 'Nioh 2 - Darkness in the Capital',
+    description: '',
+    platforms: [ 'PC', 'PlayStation 4', 'PlayStation 5' ],
+    imageUrl: 'https://howlongtobeat.com/games/84043_Nioh_2_-_Darkness_in_the_Capital.jpg',
+    timeLabels: [ [Array], [Array], [Array] ],
+    gameplayMain: 5,
+    gameplayMainExtra: 11,
+    gameplayCompletionist: 12,
+    similarity: 0.13,
+    searchTerm: 'Nioh',
+    playableOn: [ 'PC', 'PlayStation 4', 'PlayStation 5' ]
+  },
+  HowLongToBeatEntry {
+    id: '81537',
+    name: "Nioh 2 - The Tengu's Disciple",
+    description: '',
+    platforms: [ 'PC', 'PlayStation 4', 'PlayStation 5' ],
+    imageUrl: 'https://howlongtobeat.com/games/81537_Nioh_2_-_The_Tengus_Disciple.jpg',
+    timeLabels: [ [Array], [Array], [Array] ],
+    gameplayMain: 4,
+    gameplayMainExtra: 10,
+    gameplayCompletionist: 11,
+    similarity: 0.14,
+    searchTerm: 'Nioh',
+    playableOn: [ 'PC', 'PlayStation 4', 'PlayStation 5' ]
+  },
+  HowLongToBeatEntry {
+    id: '85711',
+    name: 'Nioh 2 - The First Samurai',
+    description: '',
+    platforms: [ 'PC', 'PlayStation 4', 'PlayStation 5' ],
+    imageUrl: 'https://howlongtobeat.com/games/85711_Nioh_2_-_The_First_Samurai.jpg',
+    timeLabels: [ [Array], [Array], [Array] ],
+    gameplayMain: 4,
+    gameplayMainExtra: 9,
+    gameplayCompletionist: 21,
+    similarity: 0.15,
+    searchTerm: 'Nioh',
+    playableOn: [ 'PC', 'PlayStation 4', 'PlayStation 5' ]
+  },
+  HowLongToBeatEntry {
+    id: '50087',
+    name: "Nioh - Bloodshed's End DLC",
+    description: '',
+    platforms: [ 'PC', 'PlayStation 4' ],
+    imageUrl: 'https://howlongtobeat.com/games/50087_Nioh_-_Bloodsheds_End_DLC.jpg',
+    timeLabels: [ [Array], [Array], [Array] ],
+    gameplayMain: 6,
+    gameplayMainExtra: 10,
+    gameplayCompletionist: 16,
+    similarity: 0.15,
+    searchTerm: 'Nioh',
+    playableOn: [ 'PC', 'PlayStation 4' ]
+  },
+  HowLongToBeatEntry {
+    id: '47796',
+    name: 'Nioh - Defiant Honor DLC',
+    description: '',
+    platforms: [ 'PC', 'PlayStation 4' ],
+    imageUrl: 'https://howlongtobeat.com/games/47796_Nioh_-_Defiant_Honor_DLC.jpg',
+    timeLabels: [ [Array], [Array], [Array] ],
+    gameplayMain: 5,
+    gameplayMainExtra: 9,
+    gameplayCompletionist: 15,
+    similarity: 0.17,
+    searchTerm: 'Nioh',
+    playableOn: [ 'PC', 'PlayStation 4' ]
+  },
+  HowLongToBeatEntry {
+    id: '46360',
+    name: 'Nioh - Dragon of the North DLC',
+    description: '',
+    platforms: [ 'PC', 'PlayStation 4' ],
+    imageUrl: 'https://howlongtobeat.com/games/46360_Nioh_-_Dragon_of_the_north_DLC.jpg',
+    timeLabels: [ [Array], [Array], [Array] ],
+    gameplayMain: 7,
+    gameplayMainExtra: 10,
+    gameplayCompletionist: 12,
+    similarity: 0.13,
+    searchTerm: 'Nioh',
+    playableOn: [ 'PC', 'PlayStation 4' ]
+  },
+  HowLongToBeatEntry {
+    id: '94652',
+    name: 'Nioh Collection',
+    description: '',
+    platforms: [ 'PlayStation 5' ],
+    imageUrl: 'https://howlongtobeat.com/games/94652_Nioh_Collection.jpg',
+    timeLabels: [ [Array], [Array], [Array] ],
+    gameplayMain: 0,
+    gameplayMainExtra: 160,
+    gameplayCompletionist: 0,
+    similarity: 0.27,
+    searchTerm: 'Nioh',
+    playableOn: [ 'PlayStation 5' ]
+  }
+]
+*/

--- a/src/Depressurizer.Core/Models/DatabaseEntry.cs
+++ b/src/Depressurizer.Core/Models/DatabaseEntry.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Depressurizer.Core.Enums;
 using Depressurizer.Core.Helpers;
 using JetBrains.Annotations;
@@ -182,6 +183,11 @@ namespace Depressurizer.Core.Models
         ///     Unix-timestamp of last store scrape.
         /// </summary>
         public long LastStoreScrape { get; set; }
+
+        /// <summary>
+        ///     Unix-timestamp of last HLTB scrape.
+        /// </summary>
+        public long LastHLTBScrape { get; set; }
 
         /// <summary>
         ///     URL to the Metacritic page of this application.
@@ -471,6 +477,15 @@ namespace Depressurizer.Core.Models
 
             AppType result = ScrapeStoreHelper(languageCode);
             SetTypeFromStoreScrape(result);
+        }
+
+
+        /// <summary>
+        ///     Scrapes the HowLongToBeat site in the specified language.
+        /// </summary>
+        public void ScrapeHLTB()
+        {
+            HowLongToBeatEntry result = ScrapeHLTBHelper();
         }
 
         #endregion
@@ -920,6 +935,26 @@ namespace Depressurizer.Core.Models
                 AppType = typeFromStore;
             }
         }
+
+        private static HttpWebRequest GetHLTBRequest(string url)
+        {
+            HttpWebRequest req = WebRequest.CreateHttp(url);
+            req.Timeout = 10_000;
+            return req;
+        }
+
+        private HowLongToBeatEntry ScrapeHLTBHelper()
+        {
+            Logger.Verbose("Scraping {0}: Initiating scraping of the HLTB.", AppId);
+
+            HttpWebResponse resp = null;
+            var service = new HowLongToBeatService();
+
+            var result = Task.Run(() => service.Detail("2224")).GetAwaiter().GetResult();
+
+            return result;
+        }
+
 
         #endregion
     }

--- a/src/Depressurizer.Core/Models/HLTBSearchEntry.cs
+++ b/src/Depressurizer.Core/Models/HLTBSearchEntry.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using Depressurizer.Core.Enums;
+using Newtonsoft.Json;
+
+// ReSharper disable All
+
+#pragma warning disable 1591
+
+namespace Depressurizer.Core.Models
+{
+    public sealed class HLTBSearchEntry
+    {
+        #region Public Properties
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("platforms")]
+        public string[] Platforms { get; set; }
+
+        [JsonProperty("imageUrl")]
+        public string ImageUrl { get; set; }
+
+        [JsonProperty("timeLabels")]
+        public string[][] TimeLabels { get; set; }
+
+        [JsonProperty("gameplayMain")]
+        public int GameplayMain { get; set; }
+
+        [JsonProperty("gameplayMainExtra")]
+        public int GameplayMainExtra { get; set; }
+
+        [JsonProperty("gameplayCompletionist")]
+        public int GameplayCompletionist { get; set; }
+
+        [JsonProperty("similarity")]
+        public double Similarity { get; set; }
+
+        [JsonProperty("searchTerm")]
+        public string SearchTerm { get; set; }
+
+        [JsonProperty("playableOn")]
+        public string[] PlayableOn { get; set; }
+
+        #endregion
+    }
+}

--- a/src/Depressurizer.Core/Models/HTLBSearchPayload.cs
+++ b/src/Depressurizer.Core/Models/HTLBSearchPayload.cs
@@ -1,0 +1,123 @@
+﻿using System.Collections.Generic;
+using Depressurizer.Core.Enums;
+using Newtonsoft.Json;
+
+// ReSharper disable All
+
+#pragma warning disable 1591
+
+namespace Depressurizer.Core.Models
+{
+    public sealed class HLTBSearchPayload
+    {
+        #region Public Properties
+
+        [JsonProperty("searchType")]
+        public string SearchType { get; set; }
+
+        [JsonProperty("searchTerms")]
+        public List<string> SearchTerms { get; set; }
+
+        [JsonProperty("searchPage")]
+        public int SearchPage { get; set; }
+
+        [JsonProperty("size")]
+        public int Size { get; set; }
+
+        [JsonProperty("searchOptions")]
+        public SearchOptionsProperty SearchOptions { get; set; }
+        #endregion
+
+        #region Nested Types
+
+
+        public class Game
+        {
+            #region Public Properties
+
+            [JsonProperty("Playtime")]
+            public long Playtime { get; set; }
+
+            [JsonProperty("SteamAppData")]
+            public SteamAppData SteamAppData { get; set; }
+
+            #endregion
+        }
+
+        public class SearchOptionsProperty
+        {
+            [JsonProperty("games")]
+            public GamesOptions Games { get; set; }
+
+            [JsonProperty("users")]
+            public UsersOptions Users { get; set; }
+
+            [JsonProperty("filter")]
+            public string Filter { get; set; }
+
+            [JsonProperty("sort")]
+            public int Sort { get; set; }
+
+            [JsonProperty("randomizer")]
+            public int Randomizer { get; set; }
+
+        }
+
+        public class GamesOptions
+        {
+            [JsonProperty("userId")]
+            public int UserId { get; set; }
+
+            [JsonProperty("platform")]
+            public string Platform { get; set; }
+
+            [JsonProperty("sortCategory")]
+            public string SortCategory { get; set; }
+
+            [JsonProperty("rangeCategory")]
+            public string RangeCategory { get; set; }
+
+            [JsonProperty("rangeTime")]
+            public RangeTime RangeTime { get; set; }
+
+            [JsonProperty("gameplay")]
+            public GameplayOptions Gameplay { get; set; }
+
+            [JsonProperty("modifier")]
+            public string Modifier { get; set; }
+
+        }
+
+        public class UsersOptions
+        {
+            [JsonProperty("sortCategory")]
+            public string SortCategory { get; set; }
+
+        }
+
+        public class RangeTime
+        {
+            [JsonProperty("min")]
+            public int Min { get; set; }
+
+            [JsonProperty("max")]
+            public int Max { get; set; }
+
+        }
+
+        public class GameplayOptions
+        {
+            [JsonProperty("perspective")]
+            public string Perspective { get; set; }
+
+            [JsonProperty("flow")]
+            public string Flow { get; set; }
+
+            [JsonProperty("genre")]
+            public string Genre { get; set; }
+
+        }
+
+        #endregion
+    }
+}

--- a/src/Depressurizer.Tests/Depressurizer.Tests.csproj
+++ b/src/Depressurizer.Tests/Depressurizer.Tests.csproj
@@ -1,16 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+	<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Depressurizer.Tests/Models/HowLongToBeatServiceTests.cs
+++ b/src/Depressurizer.Tests/Models/HowLongToBeatServiceTests.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Threading;
+using Depressurizer.Core.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Depressurizer.Tests.Models
+{
+    public class HowLongToBeatServiceTests
+    {
+        [Fact]
+        public async Task Detail_Should_Load_Entry_For_Dark_Souls()
+        {
+            // Arrange
+            var service = new HowLongToBeatService();
+
+            // Act
+            var entry = await service.Detail("2224");
+
+            // Assert
+            entry.Should().NotBeNull();
+            entry.Id.Should().Be("2224");
+            entry.Name.Should().Be("Dark Souls");
+            entry.SearchTerm.Should().Be("Dark Souls");
+            entry.ImageUrl.Should().NotBeNullOrEmpty();
+            entry.Platforms.Should().HaveCount(3);
+            entry.PlayableOn.Should().HaveCount(3);
+            entry.Description.Should().Contain("Live Through A Million Deaths & Earn Your Legacy.");
+            entry.GameplayMain.Should().BeGreaterThan(40);
+            entry.GameplayCompletionist.Should().BeGreaterThan(100);
+        }
+
+        [Fact]
+        public async Task Detail_Should_Abort_Loading_Entry_For_Dark_Souls()
+        {
+            // Arrange
+            var service = new HowLongToBeatService();
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await service.Detail("2224", cancellationTokenSource.Token));
+        }
+
+        [Fact]
+        public async Task Detail_Should_Fail_To_Load_Entry_For_404()
+        {
+            // Arrange
+            var service = new HowLongToBeatService();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(async () => await service.Detail("123"));
+        }
+
+        [Fact]
+        public async Task Search_Should_Have_No_Results_For_Dorks()
+        {
+            // Arrange
+            var service = new HowLongToBeatService();
+
+            // Act
+            var result = await service.Search("dorks");
+
+            // Assert
+            result.Should().NotBeNull().And.BeEmpty();
+        }
+
+        [Fact]
+        public async Task Search_Should_Have_At_Least_Three_Results_For_Dark_Souls_III()
+        {
+            // Arrange
+            var service = new HowLongToBeatService();
+
+            // Act
+            var result = await service.Search("dark souls III");
+
+            // Assert
+            result.Should().HaveCountGreaterOrEqualTo(3);
+            result[0].Id.Should().Be("26803");
+            result[0].Name.Should().Be("Dark Souls III");
+            result[0].GameplayMain.Should().BeGreaterThan(30);
+            result[0].GameplayCompletionist.Should().BeGreaterThan(80);
+        }
+
+        [Fact]
+        public async Task Search_Should_Abort_Searching_For_Dark_Souls_III()
+        {
+            // Arrange
+            var service = new HowLongToBeatService();
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            // Act & Assert
+            await Assert.ThrowsAsync<TaskCanceledException>(async () => await service.Search("dark souls III", cancellationTokenSource.Token));
+        }
+
+        [Fact]
+        public async Task Search_Should_Have_One_Result_With_100_Percent_Similarity_For_Persona_4_Golden()
+        {
+            // Arrange
+            var service = new HowLongToBeatService();
+
+            // Act
+            var result = await service.Search("Persona 4 Golden");
+
+            // Assert
+            result.Should().HaveCount(1);
+            //result[0].Similarity.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task Entries_Without_Any_Time_Settings_Should_Have_Zero_Hour_Result()
+        {
+            // Arrange
+            var service = new HowLongToBeatService();
+
+            // Act
+            var result = await service.Search("Surge");
+
+            // Assert
+            result.Should().NotBeNull().And.NotBeEmpty();
+            result[0].GameplayMain.Should().Be(0);
+        }
+    }
+}

--- a/src/Depressurizer.Tests/Models/HowLongToBeatServiceTests.cs
+++ b/src/Depressurizer.Tests/Models/HowLongToBeatServiceTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Depressurizer.Core.Helpers;
 using FluentAssertions;
 using Xunit;
+using System.Net.Http;
 
 namespace Depressurizer.Tests.Models
 {
@@ -49,8 +50,13 @@ namespace Depressurizer.Tests.Models
             // Arrange
             var service = new HowLongToBeatService();
 
-            // Act & Assert
-            await Assert.ThrowsAsync<ArgumentException>(async () => await service.Detail("123"));
+            // Act
+            var exception = await Record.ExceptionAsync(async () => await service.Detail("123"));
+
+            // Assert
+            Assert.NotNull(exception);
+            Assert.IsType<System.Exception>(exception);
+            Assert.IsType<HttpRequestException>(exception.InnerException);
         }
 
         [Fact]

--- a/src/Depressurizer/Depressurizer.csproj
+++ b/src/Depressurizer/Depressurizer.csproj
@@ -109,6 +109,9 @@
     </Compile>
     <Compile Include="AutoCats\AutoCatHoursPlayed.cs" />
     <Compile Include="CommaClusteringStrategy.cs" />
+    <Compile Include="Dialogs\ScrapeDialogHLTB.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Dialogs\SteamKeyDialog.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/src/Depressurizer/Dialogs/ScrapeDialogHLTB.cs
+++ b/src/Depressurizer/Dialogs/ScrapeDialogHLTB.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Depressurizer.Core.Models;
+using Depressurizer.Properties;
+
+namespace Depressurizer.Dialogs
+{
+    internal class ScrapeDialogHLTB : CancelableDialog
+    {
+        #region Fields
+
+        private readonly ConcurrentQueue<ScrapeJob> _queue;
+
+        private readonly ConcurrentQueue<DatabaseEntry> _results = new ConcurrentQueue<DatabaseEntry>();
+
+        private DateTime _start;
+
+        private string _timeLeft;
+
+        #endregion
+
+        #region Constructors and Destructors
+
+        public ScrapeDialogHLTB(IEnumerable<ScrapeJob> scrapeJobs) : base(Resources.ScrapeDialog_Title, true)
+        {
+            _queue = new ConcurrentQueue<ScrapeJob>(scrapeJobs);
+            TotalJobs = _queue.Count;
+        }
+
+        #endregion
+
+        #region Properties
+
+        private static Database Database => Database.Instance;
+
+        #endregion
+
+        #region Methods
+
+        protected override void CancelableDialog_Load(object sender, EventArgs e)
+        {
+            _start = DateTime.UtcNow;
+            base.CancelableDialog_Load(sender, e);
+        }
+
+        protected override void Finish()
+        {
+            if (Canceled || _results == null)
+            {
+                return;
+            }
+
+            SetText(Resources.ApplyingData);
+
+            foreach (DatabaseEntry g in _results)
+            {
+                // find the game in the database and update the HLTB metadata for the game
+                // how do we handle it if the game does not exist in the database?
+                // might need to disambiguate if the name is not a match to the steam id - this should be dealt with in the scrape job though
+                // Database.Add(g);
+            }
+
+            SetText(Resources.AppliedData);
+        }
+
+        protected override void RunProcess()
+        {
+            bool stillRunning = true;
+            while (!Stopped && stillRunning)
+            {
+                stillRunning = RunNextJob();
+            }
+
+            OnThreadCompletion();
+        }
+
+        protected override void UpdateText()
+        {
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine(string.Format(CultureInfo.CurrentCulture, Resources.ScrapedProgress, JobsCompleted, TotalJobs));
+
+            string timeLeft = string.Format(CultureInfo.CurrentCulture, "{0}: ", Resources.TimeLeft) + "{0}";
+            if (JobsCompleted > 0)
+            {
+                TimeSpan timeRemaining = TimeSpan.FromTicks(DateTime.UtcNow.Subtract(_start).Ticks * (TotalJobs - (JobsCompleted + 1)) / (JobsCompleted + 1));
+                if (timeRemaining.TotalHours >= 1)
+                {
+                    _timeLeft = string.Format(CultureInfo.InvariantCulture, timeLeft, timeRemaining.Hours + ":" + (timeRemaining.Minutes < 10 ? "0" + timeRemaining.Minutes : timeRemaining.Minutes.ToString(CultureInfo.InvariantCulture)) + ":" + (timeRemaining.Seconds < 10 ? "0" + timeRemaining.Seconds : timeRemaining.Seconds.ToString(CultureInfo.InvariantCulture)));
+                }
+                else if (timeRemaining.TotalSeconds >= 60)
+                {
+                    _timeLeft = string.Format(CultureInfo.InvariantCulture, timeLeft, (timeRemaining.Minutes < 10 ? "0" + timeRemaining.Minutes : timeRemaining.Minutes.ToString(CultureInfo.InvariantCulture)) + ":" + (timeRemaining.Seconds < 10 ? "0" + timeRemaining.Seconds : timeRemaining.Seconds.ToString(CultureInfo.InvariantCulture)));
+                }
+                else
+                {
+                    _timeLeft = string.Format(CultureInfo.InvariantCulture, timeLeft, timeRemaining.Seconds + "s");
+                }
+            }
+            else
+            {
+                _timeLeft = string.Format(CultureInfo.CurrentCulture, timeLeft, Resources.Unknown);
+            }
+
+            stringBuilder.AppendLine(_timeLeft);
+            SetText(stringBuilder.ToString());
+        }
+
+        private bool GetNextJob(out ScrapeJob job)
+        {
+            return _queue.TryDequeue(out job);
+        }
+
+        private bool RunNextJob()
+        {
+            if (!GetNextJob(out ScrapeJob job))
+            {
+                return false;
+            }
+
+            // this should find an existing database entry, as HLTB is a secondary source of data
+            DatabaseEntry newGame = new DatabaseEntry(job.Id)
+            {
+                // we might need to set the game name here so we can scrape the website by the name, not the ID
+                // the game name is not available in the ScrapeJob object currently
+                AppId = job.ScrapeId
+            };
+
+            // scrape the website
+            // this will need a new "ScrapeStore" specifically for HLTB, as the current one is for Steam
+            newGame.ScrapeStore(FormMain.SteamWebApiKey, Database.LanguageCode);
+            if (Stopped)
+            {
+                return false;
+            }
+
+            // LastStoreScrape needs to be replaced with a new field for HLTB
+            if (newGame.LastStoreScrape != 0)
+            {
+                _results.Enqueue(newGame);
+            }
+
+            OnJobCompletion();
+
+            return true;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
Replaces the deprecated HowLongToBeat API website with an API client that supports search via the HowLongToBeat Search API and/or scraping the HowLongToBeat HTML game page. HLTB API is inspired by [howlongtobeat](https://www.npmjs.com/package/howlongtobeat) npm package.

**Completed**
- Completed a search/detail API for fetching HLTB data
- Unit testing for search and detail HLTB API

**Todo**
- Replace existing API calls to howlongtobeatsteam.com with search/scrape as appropriate (search API preferred)
- Replace UI dialog integrations to support bulk scraping similar to existing Steam scraping integration
- Improve efficiency of API calls to reduce potential for negative impact on howlongtobeat.com and potential blocking by CSRF tokenisatio. Implement via caching/API call optimisation.